### PR TITLE
Makefile was changed to ensure the target installation dir is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ debug:
 	cp -f ./define.debug ./define.h
 	make -C /lib/modules/$(shell uname -r)/build/ SUBDIRS=$(PWD) modules
 install:
+	mkdir -p /lib/modules/$(shell uname -r)/kernel/drivers/scsi
 	cp $(TARGET_MODULE).ko /lib/modules/$(shell uname -r)/kernel/drivers/scsi -f
 clean:
 	rm -f *.o *.ko


### PR DESCRIPTION
This is done for customly-built kernels which usually do not have much modules, thus `drivers/scsi` folder may be not present.