### PR TITLE
Update rtsx_chip.h

### DIFF
--- a/rtsx_chip.h
+++ b/rtsx_chip.h
@@ -316,7 +316,7 @@ struct sense_data_t {
 #define SG_INT			0x04
 
 // Commented to remove the redefined variable in /include/linux/blkdev.h
-// #define SG_END			0x02
+#define SG_END			0x02
 
 #define SG_VALID		0x01
 


### PR DESCRIPTION
Make fails with error: /var/lib/dkms/rts5227/1.07/build/rtsx_transport.c: In function ‘rtsx_add_sg_tbl’: /var/lib/dkms/rts5227/1.07/build/rtsx_transport.c:352:26: error: ‘SG_END’ undeclared (first use in this function);
Works after uncommenting #define SG_END 0x02 
This is the upstream to: https://aur.archlinux.org/packages/rts5227-dkms

Hi! This is my first Github pull request, so I'm not really sure if I'm doing it right.