### PR TITLE
Fix build on linux>=5.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Driver for Realtek PCI-Express card reader
 #
-# Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+# Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -45,5 +45,4 @@ install:
 clean:
 	rm -f *.o *.ko
 	rm -f $(TARGET_MODULE).mod.c
-
 

--- a/debug.h
+++ b/debug.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -45,5 +45,5 @@
 #define RTSX_DEBUGPN(x) DEBUGPN x
 #define RTSX_DEBUG(x) DEBUG(x)
 
-#endif   
+#endif
 

--- a/define.debug
+++ b/define.debug
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/define.h
+++ b/define.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/define.release
+++ b/define.release
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/general.c
+++ b/general.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -31,7 +31,7 @@ int bit1cnt_long(u32 data)
 	int i, cnt = 0;
 	for (i = 0; i < 32; i++) {
 		if (data & 0x01)
-			cnt ++;	
+			cnt ++;
 		data >>= 1;
 	}
 	return cnt;

--- a/general.h
+++ b/general.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -32,5 +32,5 @@ extern int trigger_enabled;
 
 int bit1cnt_long(u32 data);
 
-#endif 
+#endif
 

--- a/ms.c
+++ b/ms.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -35,7 +35,7 @@ static inline void ms_set_err_code(struct rtsx_chip *chip, u8 err_code)
 	struct ms_info *ms_card = &(chip->ms_card);
 
 	ms_card->err_code = err_code;
-	
+
 #if DBG
 	if (err_code != MS_NO_ERROR) {
 		int i;
@@ -88,12 +88,12 @@ static int ms_transfer_tpc(struct rtsx_chip *chip, u8 trans_mode, u8 tpc, u8 cnt
 
 	ptr = rtsx_get_cmd_data(chip) + 1;
 
-	if (!(tpc & 0x08)) {		
+	if (!(tpc & 0x08)) {
 		if (*ptr & MS_CRC16_ERR) {
 			ms_set_err_code(chip, MS_CRC16_ERROR);
 			TRACE_RET(chip, ms_parse_err_code(chip));
 		}
-	} else {			
+	} else {
 		if (CHK_MSPRO(ms_card) && !(*ptr & 0x80)) {
 			if (*ptr & (MS_INT_ERR | MS_INT_CMDNK)) {
 				ms_set_err_code(chip, MS_CMD_NK);
@@ -111,7 +111,7 @@ static int ms_transfer_tpc(struct rtsx_chip *chip, u8 trans_mode, u8 tpc, u8 cnt
 	return STATUS_SUCCESS;
 }
 
-static int ms_transfer_data(struct rtsx_chip *chip, u8 trans_mode, u8 tpc, u16 sec_cnt, 
+static int ms_transfer_data(struct rtsx_chip *chip, u8 trans_mode, u8 tpc, u16 sec_cnt,
 		u8 cfg, int mode_2k, int use_sg, void *buf, int buf_len)
 {
 	int retval;
@@ -200,18 +200,18 @@ static int ms_write_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *da
 	retval = rtsx_send_cmd(chip, MS_CARD, 5000);
 	if (retval < 0) {
 		u8 val = 0;
-		
+
 		rtsx_read_register(chip, MS_TRANS_CFG, &val);
 		RTSX_DEBUGP(("MS_TRANS_CFG: 0x%02x\n", val));
-		
+
 		rtsx_clear_ms_error(chip);
-		
-		if (!(tpc & 0x08)) {		
+
+		if (!(tpc & 0x08)) {
 			if (val & MS_CRC16_ERR) {
 				ms_set_err_code(chip, MS_CRC16_ERROR);
 				TRACE_RET(chip, ms_parse_err_code(chip));
 			}
-		} else {			
+		} else {
 			if (CHK_MSPRO(ms_card) && !(val & 0x80)) {
 				if (val & (MS_INT_ERR | MS_INT_CMDNK)) {
 					ms_set_err_code(chip, MS_CMD_NK);
@@ -224,8 +224,8 @@ static int ms_write_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *da
 			ms_set_err_code(chip, MS_TO_ERROR);
 			TRACE_RET(chip, ms_parse_err_code(chip));
 		}
-		
-		
+
+
 		ms_set_err_code(chip, MS_TO_ERROR);
 		TRACE_RET(chip, ms_parse_err_code(chip));
 	}
@@ -244,7 +244,7 @@ static int ms_read_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *dat
 	}
 
 	rtsx_init_cmd(chip);
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TPC, 0xFF, tpc);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, MS_BYTE_CNT, 0xFF, cnt);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANS_CFG, 0xFF, cfg);
@@ -265,17 +265,17 @@ static int ms_read_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *dat
 	retval = rtsx_send_cmd(chip, MS_CARD, 5000);
 	if (retval < 0) {
 		u8 val = 0;
-		
+
 		rtsx_read_register(chip, MS_TRANS_CFG, &val);
-		
+
 		rtsx_clear_ms_error(chip);
-				
-		if (!(tpc & 0x08)) {		
+
+		if (!(tpc & 0x08)) {
 			if (val & MS_CRC16_ERR) {
 				ms_set_err_code(chip, MS_CRC16_ERROR);
 				TRACE_RET(chip, ms_parse_err_code(chip));
 			}
-		} else {			
+		} else {
 			if (CHK_MSPRO(ms_card) && !(val & 0x80)) {
 				if (val & (MS_INT_ERR | MS_INT_CMDNK)) {
 					ms_set_err_code(chip, MS_CMD_NK);
@@ -288,7 +288,7 @@ static int ms_read_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *dat
 			ms_set_err_code(chip, MS_TO_ERROR);
 			TRACE_RET(chip, ms_parse_err_code(chip));
 		}
-	
+
 		ms_set_err_code(chip, MS_TO_ERROR);
 		TRACE_RET(chip, ms_parse_err_code(chip));
 	}
@@ -298,7 +298,7 @@ static int ms_read_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *dat
 	for (i = 0; i < data_len; i++) {
 		data[i] = ptr[i];
 	}
-	
+
 	if ((tpc == PRO_READ_SHORT_DATA) && (data_len == 8)) {
 		RTSX_DEBUGP(("Read format progress:\n"));
 		RTSX_DUMP(ptr, cnt);
@@ -307,7 +307,7 @@ static int ms_read_bytes(struct rtsx_chip *chip, u8 tpc, u8 cnt, u8 cfg, u8 *dat
 	return STATUS_SUCCESS;
 }
 
-static int ms_set_rw_reg_addr(struct rtsx_chip *chip, 
+static int ms_set_rw_reg_addr(struct rtsx_chip *chip,
 		u8 read_start, u8 read_cnt, u8 write_start, u8 write_cnt)
 {
 	int retval, i;
@@ -332,7 +332,7 @@ static int ms_set_rw_reg_addr(struct rtsx_chip *chip,
 static int ms_send_cmd(struct rtsx_chip *chip, u8 cmd, u8 cfg)
 {
 	u8 data[2];
-	
+
 	data[0] = cmd;
 	data[1] = 0;
 
@@ -363,7 +363,7 @@ static int ms_set_init_para(struct rtsx_chip *chip)
 			ms_card->ms_clock = chip->fpga_ms_1bit_clk;
 		}
 	}
-	
+
 	retval = switch_clock(chip, ms_card->ms_clock);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -386,27 +386,27 @@ static int ms_switch_clock(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = switch_clock(chip, ms_card->ms_clock);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 int ms_pull_ctl_disable(struct rtsx_chip *chip)
 {
 	RTSX_WRITE_REG(chip, CARD_PULL_CTL5, 0xFF, 0x55);
 	RTSX_WRITE_REG(chip, CARD_PULL_CTL6, 0xFF, 0x15);
-	
+
 	return STATUS_SUCCESS;
 }
 
 int ms_pull_ctl_enable(struct rtsx_chip *chip)
 {
 	int retval;
-	
+
 	/* MS CD: pull up
 	 * others: pull down
 	 */
@@ -419,7 +419,7 @@ int ms_pull_ctl_enable(struct rtsx_chip *chip)
 	if (retval < 0) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -435,7 +435,7 @@ static int ms_prepare_reset(struct rtsx_chip *chip)
 	ms_card->delay_write.delay_write_flag = 0;
 
 	ms_card->pro_under_formatting = 0;
-	
+
 	retval = ms_power_off_card3v3(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -444,7 +444,7 @@ static int ms_prepare_reset(struct rtsx_chip *chip)
 	if (!chip->ft2_fast_mode) {
 		wait_timeout(250);
 	}
-	
+
 	retval = enable_card_clock(chip, MS_CARD);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -465,7 +465,7 @@ static int ms_prepare_reset(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 		wait_timeout(150);
-	
+
 #ifdef SUPPORT_OCP
 		oc_mask = SD_OC_NOW | SD_OC_EVER;
 		if (chip->ocp_stat & oc_mask) {
@@ -478,10 +478,10 @@ static int ms_prepare_reset(struct rtsx_chip *chip)
 	RTSX_WRITE_REG(chip, CARD_OE, MS_OUTPUT_EN, MS_OUTPUT_EN);
 
 	if (chip->asic_code) {
-		RTSX_WRITE_REG(chip, MS_CFG, 0xFF, 
+		RTSX_WRITE_REG(chip, MS_CFG, 0xFF,
 			SAMPLE_TIME_RISING | PUSH_TIME_DEFAULT | NO_EXTEND_TOGGLE | MS_BUS_WIDTH_1);
 	} else {
-		RTSX_WRITE_REG(chip, MS_CFG, 0xFF, 
+		RTSX_WRITE_REG(chip, MS_CFG, 0xFF,
 			SAMPLE_TIME_FALLING | PUSH_TIME_DEFAULT | NO_EXTEND_TOGGLE | MS_BUS_WIDTH_1);
 	}
 	RTSX_WRITE_REG(chip, MS_TRANS_CFG, 0xFF, NO_WAIT_INT | NO_AUTO_READ_INT_REG);
@@ -491,7 +491,7 @@ static int ms_prepare_reset(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -518,7 +518,7 @@ static int ms_identify_media_type(struct rtsx_chip *chip, int switch_8bit_bus)
 
 	RTSX_READ_REG(chip, PPBUF_BASE2 + 2, &val);
 	RTSX_DEBUGP(("Type register: 0x%x\n", val));
-	if (val != 0x01) {  
+	if (val != 0x01) {
 		if (val != 0x02) {
 			ms_card->check_ms_flow = 1;
 		}
@@ -547,7 +547,7 @@ static int ms_identify_media_type(struct rtsx_chip *chip, int switch_8bit_bus)
 		ms_card->check_ms_flow = 1;
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_card->ms_type |= TYPE_MSPRO;
 
 	RTSX_READ_REG(chip, PPBUF_BASE2 + 3, &val);
@@ -607,14 +607,14 @@ static int ms_confirm_cpu_startup(struct rtsx_chip *chip)
 	}
 
 	if (val & INT_REG_ERR) {
-		if (val & INT_REG_CMDNK) {		
+		if (val & INT_REG_CMDNK) {
 			chip->card_wp |= (MS_CARD);
-		} else {				
+		} else {
 			TRACE_RET(chip, STATUS_FAIL);
-		}		
+		}
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 static int ms_switch_parallel_bus(struct rtsx_chip *chip)
@@ -682,12 +682,12 @@ static int ms_pro_reset_flow(struct rtsx_chip *chip, int switch_8bit_bus)
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-        
+
 		retval = ms_identify_media_type(chip, switch_8bit_bus);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		retval = ms_confirm_cpu_startup(chip);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
@@ -708,7 +708,7 @@ static int ms_pro_reset_flow(struct rtsx_chip *chip, int switch_8bit_bus)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-		
+
 	RTSX_WRITE_REG(chip, MS_CFG, 0x18, MS_BUS_WIDTH_4);
 
 	RTSX_WRITE_REG(chip, MS_CFG, PUSH_TIME_ODD, PUSH_TIME_ODD);
@@ -734,36 +734,36 @@ static int msxc_change_power(struct rtsx_chip *chip, u8 mode)
 {
 	int retval;
 	u8 buf[6];
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_set_rw_reg_addr(chip, 0, 0, Pro_DataCount1, 6);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	buf[0] = 0;
 	buf[1] = mode;
 	buf[2] = 0;
 	buf[3] = 0;
 	buf[4] = 0;
 	buf[5] = 0;
-	
+
 	retval = ms_write_bytes(chip, PRO_WRITE_REG , 6, NO_WAIT_INT, buf, 6);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = ms_send_cmd(chip, XC_CHG_POWER, WAIT_INT);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_READ_REG(chip, MS_TRANS_CFG, buf);
 	if (buf[0] & (MS_INT_CMDNK | MS_INT_ERR)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 #endif
@@ -831,7 +831,7 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 			rtsx_free_dma_buf(chip, buf);
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA, 
+		retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA,
 				0x40, WAIT_INT, 0, 0, buf, 64 * 512);
 		if (retval == STATUS_SUCCESS) {
 			break;
@@ -884,32 +884,32 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 		int cur_addr_off = 16 + i * 12;
 
 #ifdef SUPPORT_MSXC
-		if ((buf[cur_addr_off + 8] == 0x10) || (buf[cur_addr_off + 8] == 0x13)) 
+		if ((buf[cur_addr_off + 8] == 0x10) || (buf[cur_addr_off + 8] == 0x13))
 #else
-		if (buf[cur_addr_off + 8] == 0x10) 
+		if (buf[cur_addr_off + 8] == 0x10)
 #endif
 		{
-			sys_info_addr = ((u32)buf[cur_addr_off + 0] << 24) | 
-				((u32)buf[cur_addr_off + 1] << 16) | 
+			sys_info_addr = ((u32)buf[cur_addr_off + 0] << 24) |
+				((u32)buf[cur_addr_off + 1] << 16) |
 				((u32)buf[cur_addr_off + 2] << 8) | buf[cur_addr_off + 3];
-			sys_info_size = ((u32)buf[cur_addr_off + 4] << 24) | 
-				((u32)buf[cur_addr_off + 5] << 16) | 
+			sys_info_size = ((u32)buf[cur_addr_off + 4] << 24) |
+				((u32)buf[cur_addr_off + 5] << 16) |
 				((u32)buf[cur_addr_off + 6] << 8) | buf[cur_addr_off + 7];
-			RTSX_DEBUGP(("sys_info_addr = 0x%x, sys_info_size = 0x%x\n", 
+			RTSX_DEBUGP(("sys_info_addr = 0x%x, sys_info_size = 0x%x\n",
 					sys_info_addr, sys_info_size));
-			if (sys_info_size != 96)  {  
+			if (sys_info_size != 96)  {
 				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 			if (sys_info_addr < 0x1A0) {
-				rtsx_free_dma_buf(chip, buf);			
+				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 			if ((sys_info_size + sys_info_addr) > 0x8000) {
 				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-			
+
 #ifdef SUPPORT_MSXC
 			if (buf[cur_addr_off + 8] == 0x13) {
 				ms_card->ms_type |= MS_XC;
@@ -923,30 +923,30 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 		}
 #ifdef SUPPORT_PCGL_1P18
 		if (buf[cur_addr_off + 8] == 0x15) {
-			model_name_addr = ((u32)buf[cur_addr_off + 0] << 24) | 
-				((u32)buf[cur_addr_off + 1] << 16) | 
+			model_name_addr = ((u32)buf[cur_addr_off + 0] << 24) |
+				((u32)buf[cur_addr_off + 1] << 16) |
 				((u32)buf[cur_addr_off + 2] << 8) | buf[cur_addr_off + 3];
-			model_name_size = ((u32)buf[cur_addr_off + 4] << 24) | 
-				((u32)buf[cur_addr_off + 5] << 16) | 
+			model_name_size = ((u32)buf[cur_addr_off + 4] << 24) |
+				((u32)buf[cur_addr_off + 5] << 16) |
 				((u32)buf[cur_addr_off + 6] << 8) | buf[cur_addr_off + 7];
-			RTSX_DEBUGP(("model_name_addr = 0x%x, model_name_size = 0x%x\n", 
+			RTSX_DEBUGP(("model_name_addr = 0x%x, model_name_size = 0x%x\n",
 					model_name_addr, model_name_size));
-			if (model_name_size != 48)  {  
+			if (model_name_size != 48)  {
 				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 			if (model_name_addr < 0x1A0) {
-				rtsx_free_dma_buf(chip, buf);			
+				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 			if ((model_name_size + model_name_addr) > 0x8000) {
 				rtsx_free_dma_buf(chip, buf);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-			
+
 			found_model_name = 1;
 		}
-		
+
 		if (found_sys_info && found_model_name) {
 			break;
 		}
@@ -963,13 +963,13 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 	sub_class = buf[sys_info_addr + 46];
 #ifdef SUPPORT_MSXC
 	if (CHK_MSXC(ms_card)) {
-		xc_total_blk = ((u32)buf[sys_info_addr + 6] << 24) | 
-				((u32)buf[sys_info_addr + 7] << 16) | 
-				((u32)buf[sys_info_addr + 8] << 8) | 
+		xc_total_blk = ((u32)buf[sys_info_addr + 6] << 24) |
+				((u32)buf[sys_info_addr + 7] << 16) |
+				((u32)buf[sys_info_addr + 8] << 8) |
 				buf[sys_info_addr + 9];
-		xc_blk_size = ((u32)buf[sys_info_addr + 32] << 24) | 
-				((u32)buf[sys_info_addr + 33] << 16) | 
-				((u32)buf[sys_info_addr + 34] << 8) | 
+		xc_blk_size = ((u32)buf[sys_info_addr + 32] << 24) |
+				((u32)buf[sys_info_addr + 33] << 16) |
+				((u32)buf[sys_info_addr + 34] << 8) |
 				buf[sys_info_addr + 35];
 		RTSX_DEBUGP(("xc_total_blk = 0x%x, xc_blk_size = 0x%x\n", xc_total_blk, xc_blk_size));
 	} else {
@@ -983,7 +983,7 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 	RTSX_DEBUGP(("total_blk = 0x%x, blk_size = 0x%x\n", total_blk, blk_size));
 #endif
 
-	RTSX_DEBUGP(("class_code = 0x%x, device_type = 0x%x, sub_class = 0x%x\n", 
+	RTSX_DEBUGP(("class_code = 0x%x, device_type = 0x%x, sub_class = 0x%x\n",
 			class_code, device_type, sub_class));
 
 	memcpy(ms_card->raw_sys_info, buf + sys_info_addr, 96);
@@ -1014,19 +1014,19 @@ static int ms_read_attribute_info(struct rtsx_chip *chip)
 #endif
 
 	if (device_type != 0x00) {
-		if ((device_type == 0x01) || (device_type == 0x02) 
+		if ((device_type == 0x01) || (device_type == 0x02)
 			|| (device_type == 0x03)) {
 			chip->card_wp |= MS_CARD;
 		} else {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
-	if (sub_class & 0xC0) { 
+
+	if (sub_class & 0xC0) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	RTSX_DEBUGP(("class_code: 0x%x, device_type: 0x%x, sub_class: 0x%x\n", 
+	RTSX_DEBUGP(("class_code: 0x%x, device_type: 0x%x, sub_class: 0x%x\n",
 		class_code, device_type, sub_class));
 
 #ifdef SUPPORT_MSXC
@@ -1052,7 +1052,7 @@ static int reset_ms_pro(struct rtsx_chip *chip)
 	int retval;
 #ifdef XC_POWERCLASS
 	u8 change_power_class;
-	
+
 	if (chip->ms_power_class_en & 0x02) {
 		change_power_class = 2;
 	} else if (chip->ms_power_class_en & 0x01) {
@@ -1076,7 +1076,7 @@ Retry:
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	retval = ms_read_attribute_info(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1086,19 +1086,19 @@ Retry:
 	if (CHK_HG8BIT(ms_card)) {
 		change_power_class = 0;
 	}
-	
+
 	if (change_power_class && CHK_MSXC(ms_card)) {
 		u8 power_class_en = chip->ms_power_class_en;
-		
+
 		RTSX_DEBUGP(("power_class_en = 0x%x\n", power_class_en));
 		RTSX_DEBUGP(("change_power_class = %d\n", change_power_class));
-		
+
 		if (change_power_class) {
 			power_class_en &= (1 << (change_power_class - 1));
 		} else {
 			power_class_en = 0;
 		}
-		
+
 		if (power_class_en) {
 			u8 power_class_mode = (ms_card->raw_sys_info[46] & 0x18) >> 3;
 			RTSX_DEBUGP(("power_class_mode = 0x%x", power_class_mode));
@@ -1157,7 +1157,7 @@ static int ms_read_status_reg(struct rtsx_chip *chip)
 }
 
 
-static int ms_read_extra_data(struct rtsx_chip *chip, 
+static int ms_read_extra_data(struct rtsx_chip *chip,
 		u16 block_addr, u8 page_num, u8 *buf, int buf_len)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
@@ -1241,7 +1241,7 @@ static int ms_read_extra_data(struct rtsx_chip *chip,
 }
 
 
-static int ms_write_extra_data(struct rtsx_chip *chip, 
+static int ms_write_extra_data(struct rtsx_chip *chip,
 		u16 block_addr, u8 page_num, u8 *buf, int buf_len)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
@@ -1307,7 +1307,7 @@ static int ms_read_page(struct rtsx_chip *chip, u16 block_addr, u8 page_num)
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval;
 	u8 val, data[6];
-	
+
 	retval = ms_set_rw_reg_addr(chip, OverwriteFlag, MS_EXTRA_SIZE, SystemParm, 6);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1435,7 +1435,7 @@ static int ms_set_bad_block(struct rtsx_chip *chip, u16 phy_blk)
 		}
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 
@@ -1485,7 +1485,7 @@ ERASE_RTY:
 			i ++;
 			goto ERASE_RTY;
 		}
-		
+
 		ms_set_err_code(chip, MS_CMD_NK);
 		ms_set_bad_block(chip, phy_blk);
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1527,7 +1527,7 @@ static int ms_init_page(struct rtsx_chip *chip, u16 phy_blk, u16 log_blk, u8 sta
 
 	memset(extra, 0xff, MS_EXTRA_SIZE);
 
-	extra[0] = 0xf8;	
+	extra[0] = 0xf8;
 	extra[1] = 0xff;
 	extra[2] = (u8)(log_blk >> 8);
 	extra[3] = (u8)log_blk;
@@ -1547,14 +1547,14 @@ static int ms_init_page(struct rtsx_chip *chip, u16 phy_blk, u16 log_blk, u8 sta
 	return STATUS_SUCCESS;
 }
 
-static int ms_copy_page(struct rtsx_chip *chip, u16 old_blk, u16 new_blk, 
+static int ms_copy_page(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 		u16 log_blk, u8 start_page, u8 end_page)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval, rty_cnt, uncorrect_flag = 0;
 	u8 extra[MS_EXTRA_SIZE], val, i, j, data[16];
 
-	RTSX_DEBUGP(("Copy page from 0x%x to 0x%x, logical block is 0x%x\n", 
+	RTSX_DEBUGP(("Copy page from 0x%x to 0x%x, logical block is 0x%x\n",
 		old_blk, new_blk, log_blk));
 	RTSX_DEBUGP(("start_page = %d, end_page = %d\n", start_page, end_page));
 
@@ -1658,15 +1658,15 @@ static int ms_copy_page(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 					}
 					ms_write_extra_data(chip, old_blk, i, extra, MS_EXTRA_SIZE);
 					RTSX_DEBUGP(("page %d : extra[0] = 0x%x\n", i, extra[0]));
-					MS_SET_BAD_BLOCK_FLG(ms_card);	
-					
+					MS_SET_BAD_BLOCK_FLG(ms_card);
+
 					ms_set_page_status(log_blk, setPS_Error, extra, MS_EXTRA_SIZE);
 					ms_write_extra_data(chip, new_blk, i, extra, MS_EXTRA_SIZE);
 					continue;
 				}
 
 				for (rty_cnt = 0; rty_cnt < MS_MAX_RETRY_COUNT; rty_cnt ++) {
-					retval = ms_transfer_tpc(chip, MS_TM_NORMAL_WRITE, 
+					retval = ms_transfer_tpc(chip, MS_TM_NORMAL_WRITE,
 							WRITE_PAGE_DATA, 0, NO_WAIT_INT);
 					if (retval == STATUS_SUCCESS) {
 						break;
@@ -1683,7 +1683,7 @@ static int ms_copy_page(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 			}
 		}
 
-		retval = ms_set_rw_reg_addr(chip, OverwriteFlag, 
+		retval = ms_set_rw_reg_addr(chip, OverwriteFlag,
 				MS_EXTRA_SIZE, SystemParm, (6+MS_EXTRA_SIZE));
 
 		ms_set_err_code(chip, MS_NO_ERROR);
@@ -1796,7 +1796,7 @@ static int ms_copy_page(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 
 
 static int reset_ms(struct rtsx_chip *chip)
-{	
+{
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval;
 	u16 i, reg_addr, block_size;
@@ -1809,9 +1809,9 @@ static int reset_ms(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_card->ms_type |= TYPE_MS;
-	
+
 	retval = ms_send_cmd(chip, MS_RESET, NO_WAIT_INT);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1943,25 +1943,25 @@ RE_SEARCH:
 	ms_card->total_block = ((u16)ptr[8] << 8) | ptr[9];
 
 #ifdef SUPPORT_MAGIC_GATE
-	j = ptr[10];  
+	j = ptr[10];
 
-	if (ms_card->block_shift == 4)  { 
-		if (j < 2)  { 
+	if (ms_card->block_shift == 4)  {
+		if (j < 2)  {
 			ms_card->capacity = 0x1EE0;
-		} else { 
+		} else {
 			ms_card->capacity = 0x3DE0;
 		}
-	} else  { 
-		if (j < 5)  { 
+	} else  {
+		if (j < 5)  {
 			ms_card->capacity = 0x7BC0;
-		} else if (j < 0xA) { 
+		} else if (j < 0xA) {
 			ms_card->capacity = 0xF7C0;
-		} else if (j < 0x11) { 
+		} else if (j < 0x11) {
 			ms_card->capacity = 0x1EF80;
-		} else { 
+		} else {
 			ms_card->capacity = 0x3DF00;
 		}
-	}	
+	}
 #else
 	eblock_cnt = ((u16)ptr[10] << 8) | ptr[11];
 
@@ -1984,7 +1984,7 @@ RE_SEARCH:
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 
-		RTSX_WRITE_REG(chip, MS_CFG, 0x58 | MS_NO_CHECK_INT, 
+		RTSX_WRITE_REG(chip, MS_CFG, 0x58 | MS_NO_CHECK_INT,
 				MS_BUS_WIDTH_4 | PUSH_TIME_ODD | MS_NO_CHECK_INT);
 
 		ms_card->ms_type |= MS_4BIT;
@@ -2049,7 +2049,7 @@ static int ms_init_l2p_tbl(struct rtsx_chip *chip)
 		ms_card->segment[i].set_index = 0;
 		ms_card->segment[i].unused_blk_cnt = 0;
 
-		RTSX_DEBUGP(("defective block count of segment %d is %d\n", 
+		RTSX_DEBUGP(("defective block count of segment %d is %d\n",
 					i, ms_card->segment[i].disable_count));
 	}
 
@@ -2135,7 +2135,7 @@ static u16 ms_get_unused_block(struct rtsx_chip *chip, int seg_no)
 	return phy_blk;
 }
 
-static const unsigned short ms_start_idx[] = {0, 494, 990, 1486, 1982, 2478, 2974, 3470, 
+static const unsigned short ms_start_idx[] = {0, 494, 990, 1486, 1982, 2478, 2974, 3470,
 	3966, 4462, 4958, 5454, 5950, 6446, 6942, 7438, 7934};
 
 static int ms_arbitrate_l2p(struct rtsx_chip *chip, u16 phy_blk, u16 log_off, u8 us1, u8 us2)
@@ -2256,8 +2256,8 @@ static int ms_build_l2p_tbl(struct rtsx_chip *chip, int seg_no)
 			ms_set_bad_block(chip, phy_blk);
 			continue;
 		}
-		
-		
+
+
 		if (seg_no == ms_card->segment_cnt - 1) {
 			if (!(extra[1] & NOT_TRANSLATION_TABLE)) {
 				if (!(chip->card_wp & MS_CARD)) {
@@ -2295,7 +2295,7 @@ static int ms_build_l2p_tbl(struct rtsx_chip *chip, int seg_no)
 			continue;
 		}
 
-		if ((log_blk < ms_start_idx[seg_no]) || 
+		if ((log_blk < ms_start_idx[seg_no]) ||
 				(log_blk >= ms_start_idx[seg_no+1])) {
 			if (!(chip->card_wp & MS_CARD)) {
 				retval = ms_erase_block(chip, phy_blk);
@@ -2306,7 +2306,7 @@ static int ms_build_l2p_tbl(struct rtsx_chip *chip, int seg_no)
 			ms_set_unused_block(chip, phy_blk);
 			continue;
 		}
-	
+
 		if (segment->l2p_table[log_blk - ms_start_idx[seg_no]] == 0xFFFF) {
 			segment->l2p_table[log_blk - ms_start_idx[seg_no]] = phy_blk;
 			continue;
@@ -2379,7 +2379,7 @@ static int ms_build_l2p_tbl(struct rtsx_chip *chip, int seg_no)
 				}
 
 				phy_blk = ms_get_unused_block(chip, 0);
-				retval = ms_copy_page(chip, tmp_blk, phy_blk, 
+				retval = ms_copy_page(chip, tmp_blk, phy_blk,
 						log_blk, 0, ms_card->page_off + 1);
 				if (retval != STATUS_SUCCESS) {
 					TRACE_RET(chip, STATUS_FAIL);
@@ -2419,7 +2419,7 @@ int reset_ms_card(struct rtsx_chip *chip)
 	int retval;
 
 	memset(ms_card, 0, sizeof(struct ms_info));
-	
+
 	retval = enable_card_clock(chip, MS_CARD);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -2429,7 +2429,7 @@ int reset_ms_card(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_card->ms_type = 0;
 
 	retval = reset_ms_pro(chip);
@@ -2448,14 +2448,14 @@ int reset_ms_card(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (!CHK_MSPRO(ms_card)) {
 		retval = ms_build_l2p_tbl(chip, ms_card->total_block / 512 - 1);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	RTSX_DEBUGP(("ms_card->ms_type = 0x%x\n", ms_card->ms_type));
 
 	return STATUS_SUCCESS;
@@ -2495,7 +2495,7 @@ void mspro_stop_seq_mode(struct rtsx_chip *chip)
 	int retval;
 
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	if (ms_card->seq_mode) {
 		retval = ms_switch_clock(chip);
 		if (retval != STATUS_SUCCESS) {
@@ -2505,16 +2505,16 @@ void mspro_stop_seq_mode(struct rtsx_chip *chip)
 		ms_card->seq_mode = 0;
 		ms_card->total_sec_cnt = 0;
 		ms_send_cmd(chip, PRO_STOP, WAIT_INT);
-		
+
 		rtsx_write_register(chip, RBCTL, RB_FLUSH, RB_FLUSH);
-	}	
+	}
 }
 
 static inline int ms_auto_tune_clock(struct rtsx_chip *chip)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
 
 	if (chip->asic_code) {
@@ -2528,12 +2528,12 @@ static inline int ms_auto_tune_clock(struct rtsx_chip *chip)
 			ms_card->ms_clock = CLK_40;
 		}
 	}
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -2543,7 +2543,7 @@ static int mspro_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, 
 	int retval, mode_2k = 0;
 	u16 count;
 	u8 val, trans_mode, rw_tpc, rw_cmd;
-	
+
 	ms_set_err_code(chip, MS_NO_ERROR);
 
 	ms_card->cleanup_counter = 0;
@@ -2591,7 +2591,7 @@ static int mspro_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, 
 	RTSX_READ_REG(chip, MS_TRANS_CFG, &val);
 
 	if (ms_card->seq_mode) {
-		if ((ms_card->pre_dir != srb->sc_data_direction) 
+		if ((ms_card->pre_dir != srb->sc_data_direction)
 				|| ((ms_card->pre_sec_addr + ms_card->pre_sec_cnt) != start_sector)
 				|| (mode_2k && (ms_card->seq_mode & MODE_512_SEQ))
 				|| (!mode_2k && (ms_card->seq_mode & MODE_2K_SEQ))
@@ -2635,19 +2635,19 @@ static int mspro_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, 
 		}
 	}
 
-	retval = ms_transfer_data(chip, trans_mode, rw_tpc, sector_cnt, WAIT_INT, mode_2k, 
+	retval = ms_transfer_data(chip, trans_mode, rw_tpc, sector_cnt, WAIT_INT, mode_2k,
 			scsi_sg_count(srb), scsi_sglist(srb), scsi_bufflen(srb));
 	if (retval != STATUS_SUCCESS) {
 		ms_card->seq_mode = 0;
 		rtsx_read_register(chip, MS_TRANS_CFG, &val);
 		rtsx_clear_ms_error(chip);
-		
+
 		if (detect_card_cd(chip, MS_CARD) != STATUS_SUCCESS) {
 			chip->rw_need_retry = 0;
 			RTSX_DEBUGP(("No card exist, exit mspro_rw_multi_sector\n"));
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		if (val & MS_INT_BREQ) {
 			ms_send_cmd(chip, PRO_STOP, WAIT_INT);
 		}
@@ -2656,7 +2656,7 @@ static int mspro_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, 
 			chip->rw_need_retry = 1;
 			ms_auto_tune_clock(chip);
 		}
-		
+
 		TRACE_RET(chip, retval);
 	}
 
@@ -2679,7 +2679,7 @@ static int mspro_read_format_progress(struct rtsx_chip *chip, const int short_da
 	u8 data[8];
 
 	RTSX_DEBUGP(("mspro_read_format_progress, short_data_len = %d\n", short_data_len));
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		ms_card->format_status = FORMAT_FAIL;
@@ -2706,7 +2706,7 @@ static int mspro_read_format_progress(struct rtsx_chip *chip, const int short_da
 	} else {
 		cnt = (u8)short_data_len;
 	}
-	
+
 	retval = rtsx_write_register(chip, MS_CFG, MS_NO_CHECK_INT, MS_NO_CHECK_INT);
 	if (retval != STATUS_SUCCESS) {
 		ms_card->format_status = FORMAT_FAIL;
@@ -2718,11 +2718,11 @@ static int mspro_read_format_progress(struct rtsx_chip *chip, const int short_da
 		ms_card->format_status = FORMAT_FAIL;
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	total_progress = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
 	cur_progress = (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | data[7];
 
-	RTSX_DEBUGP(("total_progress = %d, cur_progress = %d\n", 
+	RTSX_DEBUGP(("total_progress = %d, cur_progress = %d\n",
 				total_progress, cur_progress));
 
 	if (total_progress == 0) {
@@ -2802,7 +2802,7 @@ int mspro_format(struct scsi_cmnd *srb, struct rtsx_chip *chip, int short_data_l
 	int retval, i;
 	u8 buf[8], tmp;
 	u16 para;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
 
 	retval = ms_switch_clock(chip);
@@ -2877,7 +2877,7 @@ int mspro_format(struct scsi_cmnd *srb, struct rtsx_chip *chip, int short_data_l
 }
 
 
-static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_blk, 
+static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_blk,
 		u8 start_page, u8 end_page, u8 *buf, unsigned int *index, unsigned int *offset)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
@@ -2897,7 +2897,7 @@ static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_b
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-       	
+
 	if (CHK_MS4BIT(ms_card)) {
 		data[0] = 0x88;
 	} else {
@@ -2951,7 +2951,7 @@ static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_b
 					if (!(chip->card_wp & MS_CARD)) {
 						reset_ms(chip);
 						ms_set_page_status(log_blk, setPS_NG, extra, MS_EXTRA_SIZE);
-						ms_write_extra_data(chip, phy_blk, 
+						ms_write_extra_data(chip, phy_blk,
 								page_addr, extra, MS_EXTRA_SIZE);
 					}
 					ms_set_err_code(chip, MS_FLASH_READ_ERROR);
@@ -2998,13 +2998,13 @@ static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_b
 
 		trans_dma_enable(DMA_FROM_DEVICE, chip, 512, DMA_512);
 
-		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF,
 				MS_TRANSFER_START |  MS_TM_NORMAL_READ);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, MS_TRANSFER, MS_TRANSFER_END, MS_TRANSFER_END);
 
 		rtsx_send_cmd_no_wait(chip);
 
-		retval = rtsx_transfer_data_partial(chip, MS_CARD, ptr, 512, scsi_sg_count(chip->srb), 
+		retval = rtsx_transfer_data_partial(chip, MS_CARD, ptr, 512, scsi_sg_count(chip->srb),
 				index, offset, DMA_FROM_DEVICE, chip->ms_timeout);
 		if (retval < 0) {
 			if (retval == -ETIMEDOUT) {
@@ -3033,8 +3033,8 @@ static int ms_read_multiple_pages(struct rtsx_chip *chip, u16 phy_blk, u16 log_b
 	return STATUS_SUCCESS;
 }
 
-static int ms_write_multiple_pages(struct rtsx_chip *chip, u16 old_blk, u16 new_blk, 
-		u16 log_blk, u8 start_page, u8 end_page, u8 *buf, 
+static int ms_write_multiple_pages(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
+		u16 log_blk, u8 start_page, u8 end_page, u8 *buf,
 		unsigned int *index, unsigned int *offset)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
@@ -3103,7 +3103,7 @@ static int ms_write_multiple_pages(struct rtsx_chip *chip, u16 old_blk, u16 new_
 	data[7] = 0xFF;
 	data[8] = (u8)(log_blk >> 8);
 	data[9] = (u8)log_blk;
-	
+
 	for (i = 0x0A; i < 0x10; i++) {
 		data[i] = 0xFF;
 	}
@@ -3165,18 +3165,18 @@ static int ms_write_multiple_pages(struct rtsx_chip *chip, u16 old_blk, u16 new_
 
 		trans_dma_enable(DMA_TO_DEVICE, chip, 512, DMA_512);
 
-		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF,
 				MS_TRANSFER_START |  MS_TM_NORMAL_WRITE);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, MS_TRANSFER, MS_TRANSFER_END, MS_TRANSFER_END);
 
 		rtsx_send_cmd_no_wait(chip);
 
-		retval = rtsx_transfer_data_partial(chip, MS_CARD, ptr, 512, scsi_sg_count(chip->srb), 
+		retval = rtsx_transfer_data_partial(chip, MS_CARD, ptr, 512, scsi_sg_count(chip->srb),
 				index, offset, DMA_TO_DEVICE, chip->ms_timeout);
 		if (retval < 0) {
 			ms_set_err_code(chip, MS_TO_ERROR);
 			rtsx_clear_ms_error(chip);
-			
+
 			if (retval == -ETIMEDOUT) {
 				TRACE_RET(chip, STATUS_TIMEDOUT);
 			} else {
@@ -3206,7 +3206,7 @@ static int ms_write_multiple_pages(struct rtsx_chip *chip, u16 old_blk, u16 new_
 				retval = ms_read_bytes(chip, GET_INT, 1, NO_WAIT_INT, &val, 1);
 				if (retval != STATUS_SUCCESS) {
 					TRACE_RET(chip, STATUS_FAIL);
-				} 
+				}
 			}
 
 			if ((page_addr == (end_page - 1)) || (page_addr == ms_card->page_off)) {
@@ -3231,14 +3231,14 @@ static int ms_finish_write(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval, seg_no;
 
-	retval = ms_copy_page(chip, old_blk, new_blk, log_blk, 
+	retval = ms_copy_page(chip, old_blk, new_blk, log_blk,
 			page_off, ms_card->page_off + 1);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
 	seg_no = old_blk >> 9;
-	
+
 	if (MS_TST_BAD_BLOCK_FLG(ms_card)) {
 		MS_CLR_BAD_BLOCK_FLG(ms_card);
 		ms_set_bad_block(chip, old_blk);
@@ -3254,7 +3254,7 @@ static int ms_finish_write(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 	return STATUS_SUCCESS;
 }
 
-static int ms_prepare_write(struct rtsx_chip *chip, u16 old_blk, u16 new_blk, 
+static int ms_prepare_write(struct rtsx_chip *chip, u16 old_blk, u16 new_blk,
 		u16 log_blk, u8 start_page)
 {
 	int retval;
@@ -3283,8 +3283,8 @@ int ms_delay_write(struct rtsx_chip *chip)
 		}
 
 		delay_write->delay_write_flag = 0;
-		retval = ms_finish_write(chip, 
-				delay_write->old_phyblock, delay_write->new_phyblock, 
+		retval = ms_finish_write(chip,
+				delay_write->old_phyblock, delay_write->new_phyblock,
 				delay_write->logblock, delay_write->pageoff);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
@@ -3328,7 +3328,7 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 		ms_rw_fail(srb, chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	log_blk = (u16)(start_sector >> ms_card->block_shift);
 	start_page = (u8)(start_sector & ms_card->page_off);
 
@@ -3349,11 +3349,11 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 
 	if (srb->sc_data_direction == DMA_TO_DEVICE) {
 #ifdef MS_DELAY_WRITE
-		if (delay_write->delay_write_flag && 
-				(delay_write->logblock == log_blk) && 
+		if (delay_write->delay_write_flag &&
+				(delay_write->logblock == log_blk) &&
 				(start_page > delay_write->pageoff)) {
 			delay_write->delay_write_flag = 0;
-			retval = ms_copy_page(chip, 
+			retval = ms_copy_page(chip,
 				delay_write->old_phyblock,
 				delay_write->new_phyblock, log_blk,
 				delay_write->pageoff, start_page);
@@ -3363,14 +3363,14 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 			}
 			old_blk = delay_write->old_phyblock;
 			new_blk = delay_write->new_phyblock;
-		} else if (delay_write->delay_write_flag && 
-				(delay_write->logblock == log_blk) && 
+		} else if (delay_write->delay_write_flag &&
+				(delay_write->logblock == log_blk) &&
 				(start_page == delay_write->pageoff)) {
 			delay_write->delay_write_flag = 0;
 			old_blk = delay_write->old_phyblock;
 			new_blk = delay_write->new_phyblock;
 		} else {
-			retval = ms_delay_write(chip); 
+			retval = ms_delay_write(chip);
 			if (retval != STATUS_SUCCESS) {
 				set_sense_type(chip, lun, SENSE_TYPE_MEDIA_WRITE_ERR);
 				TRACE_RET(chip, STATUS_FAIL);
@@ -3382,7 +3382,7 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 				set_sense_type(chip, lun, SENSE_TYPE_MEDIA_WRITE_ERR);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-	
+
 			retval = ms_prepare_write(chip, old_blk, new_blk, log_blk, start_page);
 			if (retval != STATUS_SUCCESS) {
 				if (detect_card_cd(chip, MS_CARD) != STATUS_SUCCESS) {
@@ -3423,17 +3423,17 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 			end_page = start_page + (u8)total_sec_cnt;
 		}
 		page_cnt = end_page - start_page;
-		
-		RTSX_DEBUGP(("start_page = %d, end_page = %d, page_cnt = %d\n", 
+
+		RTSX_DEBUGP(("start_page = %d, end_page = %d, page_cnt = %d\n",
 				start_page, end_page, page_cnt));
 
 		if (srb->sc_data_direction == DMA_FROM_DEVICE) {
-			retval = ms_read_multiple_pages(chip, 
-				old_blk, log_blk, start_page, end_page, 
+			retval = ms_read_multiple_pages(chip,
+				old_blk, log_blk, start_page, end_page,
 				ptr, &index, &offset);
 		} else {
-			retval = ms_write_multiple_pages(chip, old_blk, 
-				new_blk, log_blk, start_page, end_page, 
+			retval = ms_write_multiple_pages(chip, old_blk,
+				new_blk, log_blk, start_page, end_page,
 				ptr, &index, &offset);
 		}
 
@@ -3451,8 +3451,8 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 				retval = ms_erase_block(chip, old_blk);
 				if (retval == STATUS_SUCCESS) {
 					ms_set_unused_block(chip, old_blk);
-				} 
-				ms_set_l2p_tbl(chip, seg_no, log_blk - ms_start_idx[seg_no], new_blk);	
+				}
+				ms_set_l2p_tbl(chip, seg_no, log_blk - ms_start_idx[seg_no], new_blk);
 			}
 		}
 
@@ -3494,7 +3494,7 @@ static int ms_rw_multi_sector(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 		}
-		
+
 		RTSX_DEBUGP(("seg_no = %d, old_blk = 0x%x, new_blk = 0x%x\n", seg_no, old_blk, new_blk));
 
 		start_page = 0;
@@ -3547,7 +3547,7 @@ void ms_free_l2p_tbl(struct rtsx_chip *chip)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
 	int i = 0;
-	
+
 	if (ms_card->segment != NULL) {
 		for (i = 0; i < ms_card->segment_cnt; i++) {
 			if (ms_card->segment[i].l2p_table != NULL) {
@@ -3561,7 +3561,7 @@ void ms_free_l2p_tbl(struct rtsx_chip *chip)
 		}
 		vfree(ms_card->segment);
 		ms_card->segment = NULL;
-	}	
+	}
 }
 
 #ifdef SUPPORT_MAGIC_GATE
@@ -3571,21 +3571,21 @@ int ms_poll_int(struct rtsx_chip *chip)
 {
 	int retval;
 	u8 val;
-	
+
 	rtsx_init_cmd(chip);
-	
+
 	rtsx_add_cmd(chip, CHECK_REG_CMD, MS_TRANS_CFG, MS_INT_CED, MS_INT_CED);
-	
+
 	retval = rtsx_send_cmd(chip, MS_CARD, 5000);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	val = *rtsx_get_cmd_data(chip);
 	if (val & MS_INT_ERR) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 #endif
@@ -3595,7 +3595,7 @@ static int check_ms_err(struct rtsx_chip *chip)
 {
 	int retval;
 	u8 val;
-	
+
 	retval = rtsx_read_register(chip, MS_TRANSFER, &val);
 	if (retval != STATUS_SUCCESS) {
 		return 1;
@@ -3603,7 +3603,7 @@ static int check_ms_err(struct rtsx_chip *chip)
 	if (val & MS_TRANSFER_ERR) {
 		return 1;
 	}
-	
+
 	retval = rtsx_read_register(chip, MS_TRANS_CFG, &val);
 	if (retval != STATUS_SUCCESS) {
 		return 1;
@@ -3612,7 +3612,7 @@ static int check_ms_err(struct rtsx_chip *chip)
 	if (val & (MS_INT_ERR | MS_INT_CMDNK)) {
 		return 1;
 	}
-	
+
 	return 0;
 }
 #else
@@ -3620,7 +3620,7 @@ static int check_ms_err(struct rtsx_chip *chip)
 {
 	int retval;
 	u8 val;
-	
+
 	retval = rtsx_read_register(chip, MS_TRANSFER, &val);
 	if (retval != STATUS_SUCCESS) {
 		return 1;
@@ -3628,7 +3628,7 @@ static int check_ms_err(struct rtsx_chip *chip)
 	if (val & MS_TRANSFER_ERR) {
 		return 1;
 	}
-	
+
 	return 0;
 }
 #endif
@@ -3656,13 +3656,13 @@ static int mg_send_ex_cmd(struct rtsx_chip *chip, u8 cmd, u8 entry_num)
 	if (i == MS_MAX_RETRY_COUNT) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if(check_ms_err(chip)) {
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 /**
@@ -3675,9 +3675,9 @@ static int mg_set_tpc_para_sub(struct rtsx_chip *chip, int type, u8 mg_entry_num
 {
 	int retval;
 	u8 buf[6];
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	if (type == 0) {
 		retval = ms_set_rw_reg_addr(chip, 0, 0, Pro_TPCParm, 1);
 	} else {
@@ -3686,7 +3686,7 @@ static int mg_set_tpc_para_sub(struct rtsx_chip *chip, int type, u8 mg_entry_num
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	buf[0] = 0;
 	buf[1] = 0;
 	if (type == 1) {
@@ -3699,7 +3699,7 @@ static int mg_set_tpc_para_sub(struct rtsx_chip *chip, int type, u8 mg_entry_num
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -3716,27 +3716,27 @@ int mg_set_leaf_id(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int i;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 buf1[32], buf2[12];
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	if (scsi_bufflen(srb) < 12) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = mg_send_ex_cmd(chip, MG_SET_LID, 0);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_ESTAB);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	memset(buf1, 0, 32);
 	rtsx_stor_get_xfer_buf(buf2, min(12, (int)scsi_bufflen(srb)), srb);
 	for (i = 0; i < 8; i++) {
@@ -3752,7 +3752,7 @@ int mg_set_leaf_id(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -3769,11 +3769,11 @@ int mg_get_local_EKB(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int bufflen;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 *buf = NULL;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -3783,19 +3783,19 @@ int mg_get_local_EKB(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (!buf) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
-	
+
 	buf[0] = 0x04;
 	buf[1] = 0x1A;
 	buf[2] = 0x00;
 	buf[3] = 0x00;
-	
+
 	retval = mg_send_ex_cmd(chip, MG_GET_LEKB, 0);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN);
 		TRACE_GOTO(chip, GetEKBFinish);
 	}
-	
-	retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA, 
+
+	retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA,
 				3, WAIT_INT, 0, 0, buf + 4, 1536);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN);
@@ -3807,10 +3807,10 @@ int mg_get_local_EKB(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	bufflen = min(1052, (int)scsi_bufflen(srb));
 	rtsx_stor_set_xfer_buf(buf, bufflen, srb);
-	
+
 GetEKBFinish:
 	if (buf) {
 		rtsx_free_dma_buf(chip, buf);
@@ -3821,7 +3821,7 @@ GetEKBFinish:
 /**
   * Send challenge(host) to medium.
 
-  * After receiving this SCSI command, adapter shall sequentially issues TPC commands 
+  * After receiving this SCSI command, adapter shall sequentially issues TPC commands
   * to the medium for writing 8-bytes data as challenge by host within a short data packet.
   */
 int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -3832,11 +3832,11 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int i;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 buf[32];
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -3847,7 +3847,7 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = ms_read_bytes(chip, PRO_READ_SHORT_DATA, 32, WAIT_INT, buf, 32);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM);
@@ -3858,9 +3858,9 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	memcpy(ms_card->magic_gate_id, buf, 16);
-	
+
 #ifdef READ_BYTES_WAIT_INT
 	retval = ms_poll_int(chip);
 	if (retval != STATUS_SUCCESS) {
@@ -3874,10 +3874,10 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	bufflen = min(12, (int)scsi_bufflen(srb));
 	rtsx_stor_get_xfer_buf(buf, bufflen, srb);
-	
+
 	for (i = 0; i < 8; i++) {
 		buf[i] = buf[4+i];
 	}
@@ -3894,9 +3894,9 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_card->mg_auth = 0;
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -3904,7 +3904,7 @@ int mg_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
   * Send Response and Challenge data  to host.
 
   * After receiving this SCSI command, adapter shall communicates with the medium, get
-  * parameters(HRd, Rms, MagicGateID) by using READ_SHORT_DATA TPC and send the 
+  * parameters(HRd, Rms, MagicGateID) by using READ_SHORT_DATA TPC and send the
   * data to host according to certain format required by MG-R specification.
 
   * The paremeter MagicGateID is the one that adapter has obtained from the medium by TPC
@@ -3917,11 +3917,11 @@ int mg_get_rsp_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int bufflen;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 buf1[32], buf2[36];
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -3932,7 +3932,7 @@ int mg_get_rsp_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = ms_read_bytes(chip, PRO_READ_SHORT_DATA, 32, WAIT_INT, buf1, 32);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN);
@@ -3943,15 +3943,15 @@ int mg_get_rsp_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	buf2[0] = 0x00;
 	buf2[1] = 0x22;
 	buf2[2] = 0x00;
 	buf2[3] = 0x00;
-	
+
 	memcpy(buf2 + 4, ms_card->magic_gate_id, 16);
 	memcpy(buf2 + 20, buf1, 16);
-	
+
 	bufflen = min(36, (int)scsi_bufflen(srb));
 	rtsx_stor_set_xfer_buf(buf2, bufflen, srb);
 
@@ -3962,14 +3962,14 @@ int mg_get_rsp_chg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 #endif
-	
+
 	return STATUS_SUCCESS;
 }
 
 /**
   * Send response(host) to medium.
 
-  * After receiving this SCSI command, adapter shall sequentially issues TPC commands 
+  * After receiving this SCSI command, adapter shall sequentially issues TPC commands
   * to the medium for writing 8-bytes data as challenge by host within a short data packet.
   */
 int mg_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -3980,11 +3980,11 @@ int mg_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int bufflen;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 buf[32];
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -3995,10 +3995,10 @@ int mg_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	bufflen = min(12, (int)scsi_bufflen(srb));
 	rtsx_stor_get_xfer_buf(buf, bufflen, srb);
-	
+
 	for (i = 0; i < 8; i++) {
 		buf[i] = buf[4+i];
 	}
@@ -4015,9 +4015,9 @@ int mg_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ms_card->mg_auth = 1;
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -4040,11 +4040,11 @@ int mg_get_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int bufflen;
 	unsigned int lun = SCSI_LUN(srb);
 	u8 *buf = NULL;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -4054,19 +4054,19 @@ int mg_get_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (!buf) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
-	
+
 	buf[0] = 0x04;
 	buf[1] = 0x02;
 	buf[2] = 0x00;
 	buf[3] = 0x00;
-	
+
 	retval = mg_send_ex_cmd(chip, MG_GET_IBD, ms_card->mg_entry_num);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_UNRECOVER_READ_ERR);
 		TRACE_GOTO(chip, GetICVFinish);
 	}
-	
-	retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA, 
+
+	retval = ms_transfer_data(chip, MS_TM_AUTO_READ, PRO_READ_LONG_DATA,
 				2, WAIT_INT, 0, 0, buf + 4, 1024);
 	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_UNRECOVER_READ_ERR);
@@ -4078,10 +4078,10 @@ int mg_get_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_clear_ms_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	bufflen = min(1028, (int)scsi_bufflen(srb));
 	rtsx_stor_set_xfer_buf(buf, bufflen, srb);
-	
+
 GetICVFinish:
 	if (buf) {
 		rtsx_free_dma_buf(chip, buf);
@@ -4092,7 +4092,7 @@ GetICVFinish:
 /**
   * Send ICV data to medium.
 
-  * After receiving this SCSI command, adapter shall receive 1028 bytes and write the later 1024 
+  * After receiving this SCSI command, adapter shall receive 1028 bytes and write the later 1024
   * bytes to medium by WRITE_LONG_DATA TPC consecutively.
 
    * Since the first 4-bytes data is just only a prefix to original data that sent by host, and it
@@ -4108,11 +4108,11 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 #endif
 	unsigned int lun = SCSI_LUN(srb);
 	u8 *buf = NULL;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	ms_cleanup_work(chip);
-	
+
 	retval = ms_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -4122,10 +4122,10 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (!buf) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
-	
+
 	bufflen = min(1028, (int)scsi_bufflen(srb));
 	rtsx_stor_get_xfer_buf(buf, bufflen, srb);
-	
+
 	retval = mg_send_ex_cmd(chip, MG_SET_IBD, ms_card->mg_entry_num);
 	if (retval != STATUS_SUCCESS) {
 		if (ms_card->mg_auth == 0) {
@@ -4139,7 +4139,7 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 		TRACE_GOTO(chip, SetICVFinish);
 	}
-	
+
 #ifdef MG_SET_ICV_SLOW
 	for (i = 0; i < 2; i++) {
 		udelay(50);
@@ -4152,7 +4152,7 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 		trans_dma_enable(DMA_TO_DEVICE, chip, 512, DMA_512);
 
-		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, MS_TRANSFER, 0xFF,
 				MS_TRANSFER_START |  MS_TM_NORMAL_WRITE);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, MS_TRANSFER, MS_TRANSFER_END, MS_TRANSFER_END);
 
@@ -4175,7 +4175,7 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 	}
 #else
-	retval = ms_transfer_data(chip, MS_TM_AUTO_WRITE, PRO_WRITE_LONG_DATA, 
+	retval = ms_transfer_data(chip, MS_TM_AUTO_WRITE, PRO_WRITE_LONG_DATA,
 				2, WAIT_INT, 0, 0, buf + 4, 1024);
 	if ((retval != STATUS_SUCCESS) || check_ms_err(chip)) {
 		rtsx_clear_ms_error(chip);
@@ -4191,7 +4191,7 @@ int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_GOTO(chip, SetICVFinish);
 	}
 #endif
-	
+
 SetICVFinish:
 	if (buf) {
 		rtsx_free_dma_buf(chip, buf);
@@ -4199,12 +4199,12 @@ SetICVFinish:
 	return retval;
 }
 
-#endif 
+#endif
 
 void ms_cleanup_work(struct rtsx_chip *chip)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
-	
+
 	if (CHK_MSPRO(ms_card)) {
 		if (ms_card->seq_mode) {
 			RTSX_DEBUGP(("MS Pro: stop transmission\n"));
@@ -4221,14 +4221,14 @@ void ms_cleanup_work(struct rtsx_chip *chip)
 		ms_delay_write(chip);
 		ms_card->cleanup_counter = 0;
 	}
-#endif	
+#endif
 }
 
 int ms_power_off_card3v3(struct rtsx_chip *chip)
 {
 	int retval;
-	
-	retval = disable_card_clock(chip, MS_CARD);	
+
+	retval = disable_card_clock(chip, MS_CARD);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -4238,7 +4238,7 @@ int ms_power_off_card3v3(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	} else {
-		RTSX_WRITE_REG(chip, FPGA_PULL_CTL, 
+		RTSX_WRITE_REG(chip, FPGA_PULL_CTL,
 			FPGA_MS_PULL_CTL_BIT | 0x20, FPGA_MS_PULL_CTL_BIT);
 	}
 	RTSX_WRITE_REG(chip, CARD_OE, MS_OUTPUT_EN, 0);
@@ -4248,7 +4248,7 @@ int ms_power_off_card3v3(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -4258,7 +4258,7 @@ int release_ms_card(struct rtsx_chip *chip)
 	int retval;
 
 	RTSX_DEBUGP(("release_ms_card\n"));
-	
+
 #ifdef MS_DELAY_WRITE
 	ms_card->delay_write.delay_write_flag = 0;
 #endif
@@ -4269,10 +4269,10 @@ int release_ms_card(struct rtsx_chip *chip)
 	chip->card_wp &= ~MS_CARD;
 
 	ms_free_l2p_tbl(chip);
-	
+
 	memset(ms_card->raw_sys_info, 0, 96);
 	memset(ms_card->raw_ms_id, 0, 16);
-#ifdef SUPPORT_PCGL_1P18	
+#ifdef SUPPORT_PCGL_1P18
 	memset(ms_card->raw_model_name, 0, 48);
 #endif
 

--- a/ms.h
+++ b/ms.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -148,24 +148,24 @@
 #define	NOT_BOOT_BLOCK		0x4
 #define	NOT_TRANSLATION_TABLE	0x8
 
-#define	HEADER_ID0		PPBUF_BASE2			
-#define	HEADER_ID1		PPBUF_BASE2 + 1			
-#define	DISABLED_BLOCK0		PPBUF_BASE2 + 0x170 + 4		
-#define	DISABLED_BLOCK1		PPBUF_BASE2 + 0x170 + 5		
-#define	DISABLED_BLOCK2		PPBUF_BASE2 + 0x170 + 6		
-#define	DISABLED_BLOCK3		PPBUF_BASE2 + 0x170 + 7		
-#define	BLOCK_SIZE_0		PPBUF_BASE2 + 0x1a0 + 2		
-#define	BLOCK_SIZE_1		PPBUF_BASE2 + 0x1a0 + 3		
-#define	BLOCK_COUNT_0		PPBUF_BASE2 + 0x1a0 + 4		
-#define	BLOCK_COUNT_1		PPBUF_BASE2 + 0x1a0 + 5		
-#define	EBLOCK_COUNT_0		PPBUF_BASE2 + 0x1a0 + 6		
-#define	EBLOCK_COUNT_1		PPBUF_BASE2 + 0x1a0 + 7		
-#define	PAGE_SIZE_0		PPBUF_BASE2 + 0x1a0 + 8		
-#define	PAGE_SIZE_1		PPBUF_BASE2 + 0x1a0 + 9		
+#define	HEADER_ID0		PPBUF_BASE2
+#define	HEADER_ID1		PPBUF_BASE2 + 1
+#define	DISABLED_BLOCK0		PPBUF_BASE2 + 0x170 + 4
+#define	DISABLED_BLOCK1		PPBUF_BASE2 + 0x170 + 5
+#define	DISABLED_BLOCK2		PPBUF_BASE2 + 0x170 + 6
+#define	DISABLED_BLOCK3		PPBUF_BASE2 + 0x170 + 7
+#define	BLOCK_SIZE_0		PPBUF_BASE2 + 0x1a0 + 2
+#define	BLOCK_SIZE_1		PPBUF_BASE2 + 0x1a0 + 3
+#define	BLOCK_COUNT_0		PPBUF_BASE2 + 0x1a0 + 4
+#define	BLOCK_COUNT_1		PPBUF_BASE2 + 0x1a0 + 5
+#define	EBLOCK_COUNT_0		PPBUF_BASE2 + 0x1a0 + 6
+#define	EBLOCK_COUNT_1		PPBUF_BASE2 + 0x1a0 + 7
+#define	PAGE_SIZE_0		PPBUF_BASE2 + 0x1a0 + 8
+#define	PAGE_SIZE_1		PPBUF_BASE2 + 0x1a0 + 9
 
-#define MS_Device_Type		PPBUF_BASE2 + 0x1D8		
+#define MS_Device_Type		PPBUF_BASE2 + 0x1D8
 
-#define	MS_4bit_Support	PPBUF_BASE2 + 0x1D3			
+#define	MS_4bit_Support	PPBUF_BASE2 + 0x1D3
 
 #define setPS_NG	1
 #define setPS_Error	0
@@ -222,5 +222,5 @@ int mg_get_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 int mg_set_ICV(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 #endif
 
-#endif  
+#endif
 

--- a/rtsx.c
+++ b/rtsx.c
@@ -552,13 +552,13 @@ SkipForAbort:
 	 * after the down() -- that's necessary for the thread-shutdown
 	 * case.
 	 *
-	 * complete_and_exit() goes even further than this -- it is safe in
+	 * kthread_complete_and_exit() goes even further than this -- it is safe in
 	 * the case that the thread of the caller is going away (not just
 	 * the structure) -- this is necessary for the module-remove case.
 	 * This is important in preemption kernels, which transfer the flow
 	 * of execution immediately upon a complete().
 	 */
-	complete_and_exit(&dev->control_exit, 0);
+	kthread_complete_and_exit(&dev->control_exit, 0);
 }
 
 
@@ -600,7 +600,7 @@ static int rtsx_polling_thread(void * __dev)
 		mutex_unlock(&dev->dev_mutex);
 	}
 
-	complete_and_exit(&dev->polling_exit, 0);
+	kthread_complete_and_exit(&dev->polling_exit, 0);
 }
 
 /*
@@ -788,7 +788,7 @@ static int rtsx_scan_thread(void * __dev)
 		
 	}
 
-	complete_and_exit(&dev->scanning_done, 0);
+	kthread_complete_and_exit(&dev->scanning_done, 0);
 }
 
 static void rtsx_init_options(struct rtsx_chip *chip)

--- a/rtsx.c
+++ b/rtsx.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -68,7 +68,7 @@ MODULE_PARM_DESC(msi_en, "enable msi");
 static irqreturn_t rtsx_interrupt(int irq, void *dev_id);
 
 /***********************************************************************
- * Host functions 
+ * Host functions
  ***********************************************************************/
 
 static const char* host_info(struct Scsi_Host *host)
@@ -135,14 +135,14 @@ static int queuecommand_lck(struct scsi_cmnd *srb)
 	struct rtsx_dev *dev = host_to_rtsx(srb->device->host);
 	struct rtsx_chip *chip = dev->chip;
 
-	
+
 	if (chip->srb != NULL) {
 		printk(KERN_ERR "Error in %s: chip->srb = %p\n",
 			__FUNCTION__, chip->srb);
 		return SCSI_MLQUEUE_HOST_BUSY;
 	}
 
-	
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_DISCONNECT)) {
 		printk(KERN_INFO "Fail command during disconnect\n");
 		srb->result = DID_NO_CONNECT << 16;
@@ -168,23 +168,23 @@ static int command_abort(struct scsi_cmnd *srb)
 	struct Scsi_Host *host = srb->device->host;
 	struct rtsx_dev *dev = host_to_rtsx(host);
 	struct rtsx_chip *chip = dev->chip;
-	
+
 	printk(KERN_INFO "%s called\n", __FUNCTION__);
-	
+
 	scsi_lock(host);
-	
-	
+
+
 	if (chip->srb != srb) {
 		scsi_unlock(host);
 		printk(KERN_INFO "-- nothing to abort\n");
 		return FAILED;
 	}
-	
+
 	rtsx_set_stat(chip, RTSX_STAT_ABORT);
-	
+
 	scsi_unlock(host);
-	
-	
+
+
 	wait_for_completion(&dev->notify);
 
 	return SUCCESS;
@@ -207,7 +207,7 @@ static int bus_reset(struct scsi_cmnd *srb)
 	int result = 0;
 
 	printk(KERN_INFO "%s called\n", __FUNCTION__);
-	
+
 	return result < 0 ? FAILED : SUCCESS;
 }
 
@@ -217,51 +217,51 @@ static int bus_reset(struct scsi_cmnd *srb)
  */
 
 static struct scsi_host_template rtsx_host_template = {
-	
+
 	.name =				CR_DRIVER_NAME,
 	.proc_name =			CR_DRIVER_NAME,
 	//.proc_info =			proc_info,
 	.info =				host_info,
 
-	
+
 	.queuecommand =			queuecommand,
 
-	
+
 	.eh_abort_handler =		command_abort,
 	.eh_device_reset_handler =	device_reset,
 	.eh_bus_reset_handler =		bus_reset,
 
-	
+
 	.can_queue =			1,
 	.cmd_per_lun =			1,
 
-	
+
 	.this_id =			-1,
 
 	.slave_alloc =			slave_alloc,
 	.slave_configure =		slave_configure,
 
-	
+
 	.sg_tablesize =			SG_ALL,
 
-	
+
 	.max_sectors =                  240,
 
 	/* merge commands... this seems to help performance, but
 	 * periodically someone should test to see which setting is more
 	 * optimal.
 	 */
-	
+
 	// Commented due to it is removed since kernel 5.0
 	// .use_clustering =		1,
 
-	
+
 	.emulated =			1,
 
-	
+
 	.skip_settle_delay =		1,
 
-	
+
 	.module =			THIS_MODULE
 };
 
@@ -269,10 +269,10 @@ static struct scsi_host_template rtsx_host_template = {
 static int rtsx_acquire_irq(struct rtsx_dev *dev)
 {
 	struct rtsx_chip *chip = dev->chip;
-	
-	printk(KERN_INFO "%s: chip->msi_en = %d, pci->irq = %d\n", 
+
+	printk(KERN_INFO "%s: chip->msi_en = %d, pci->irq = %d\n",
 			__FUNCTION__, chip->msi_en, dev->pci->irq);
-	
+
 	if (request_irq(dev->pci->irq, rtsx_interrupt,
 			chip->msi_en ? 0 : IRQF_SHARED,
 			CR_DRIVER_NAME, dev)) {
@@ -280,10 +280,10 @@ static int rtsx_acquire_irq(struct rtsx_dev *dev)
 		       "disabling device\n", dev->pci->irq);
 		return -1;
 	}
-	
+
 	dev->irq = dev->pci->irq;
 	pci_intx(dev->pci, !chip->msi_en);
-	
+
 	return 0;
 }
 
@@ -293,17 +293,17 @@ int rtsx_read_pci_cfg_byte(u8 bus, u8 dev, u8 func, u8 offset, u8 *val)
 	struct pci_dev *pdev;
 	u8 data;
 	u8 devfn = (dev << 3) | func;
-	
+
 	pdev = pci_get_bus_and_slot(bus, devfn);
 	if (!dev) {
 		return -1;
 	}
-	
+
 	pci_read_config_byte(pdev, offset, &data);
 	if (val) {
 		*val = data;
 	}
-	
+
 	return 0;
 }
 
@@ -322,20 +322,20 @@ static int rtsx_suspend(struct pci_dev *pci, pm_message_t state)
 		printk(KERN_ERR "Invalid memory\n");
 		return 0;
 	}
-	
-	
+
+
 	mutex_lock(&(dev->dev_mutex));
 
 	chip = dev->chip;
-	
+
 	rtsx_do_before_power_down(chip, PM_S3);
-	
+
 	if (dev->irq >= 0) {
 		synchronize_irq(dev->irq);
 		free_irq(dev->irq, (void *)dev);
 		dev->irq = -1;
 	}
-	
+
 	if (chip->msi_en) {
 		pci_disable_msi(pci);
 	}
@@ -345,9 +345,9 @@ static int rtsx_suspend(struct pci_dev *pci, pm_message_t state)
 	pci_disable_device(pci);
 	pci_set_power_state(pci, pci_choose_state(pci, state));
 
-	
+
 	mutex_unlock(&dev->dev_mutex);
-	
+
 	return 0;
 }
 
@@ -364,8 +364,8 @@ static int rtsx_resume(struct pci_dev *pci)
 	}
 
 	chip = dev->chip;
-	
-	
+
+
 	mutex_lock(&(dev->dev_mutex));
 
 	pci_set_power_state(pci, PCI_D0);
@@ -373,20 +373,20 @@ static int rtsx_resume(struct pci_dev *pci)
 	if (pci_enable_device(pci) < 0) {
 		printk(KERN_ERR "%s: pci_enable_device failed, "
 		       "disabling device\n", CR_DRIVER_NAME);
-		
+
 		mutex_unlock(&dev->dev_mutex);
 		return -EIO;
 	}
 	pci_set_master(pci);
-	
+
 	if (chip->msi_en) {
 		if (pci_enable_msi(pci) < 0) {
 			chip->msi_en = 0;
 		}
 	}
-	
+
 	if (rtsx_acquire_irq(dev) < 0) {
-		
+
 		mutex_unlock(&dev->dev_mutex);
 		return -EIO;
 	}
@@ -394,12 +394,12 @@ static int rtsx_resume(struct pci_dev *pci)
 	rtsx_write_register(chip, HOST_SLEEP_STATE, 0x03, 0x00);
 	rtsx_init_chip(chip);
 
-	
+
 	mutex_unlock(&dev->dev_mutex);
 
 	return 0;
 }
-#endif 
+#endif
 
 static void rtsx_shutdown(struct pci_dev *pci)
 {
@@ -422,7 +422,7 @@ static void rtsx_shutdown(struct pci_dev *pci)
 		free_irq(dev->irq, (void *)dev);
 		dev->irq = -1;
 	}
-	
+
 	if (chip->msi_en) {
 		pci_disable_msi(pci);
 	}
@@ -444,20 +444,20 @@ static int rtsx_control_thread(void * __dev)
 		if (wait_for_completion_interruptible(&dev->cmnd_ready))
 			break;
 
-		
+
 		mutex_lock(&(dev->dev_mutex));
 
-		
+
 		if (rtsx_chk_stat(chip, RTSX_STAT_DISCONNECT)) {
 			printk(KERN_INFO "-- rts5229-control exiting\n");
 			mutex_unlock(&dev->dev_mutex);
 			break;
 		}
 
-		
+
 		scsi_lock(host);
 
-		
+
 		if (rtsx_chk_stat(chip, RTSX_STAT_ABORT)) {
 			chip->srb->result = DID_ABORT << 16;
 			goto SkipForAbort;
@@ -465,7 +465,7 @@ static int rtsx_control_thread(void * __dev)
 
 		scsi_unlock(host);
 
-		/* reject the command if the direction indicator 
+		/* reject the command if the direction indicator
 		 * is UNKNOWN
 		 */
 		if (chip->srb->sc_data_direction == DMA_BIDIRECTIONAL) {
@@ -488,42 +488,42 @@ static int rtsx_control_thread(void * __dev)
 			chip->srb->result = DID_BAD_TARGET << 16;
 		}
 
-		
+
 		else {
 			RTSX_DEBUG(scsi_show_command(chip->srb));
 			rtsx_invoke_transport(chip->srb, chip);
 		}
 
-		
+
 		scsi_lock(host);
 
-		
-		if (!chip->srb)
-			;		
 
-		
+		if (!chip->srb)
+			;
+
+
 		else if (chip->srb->result != DID_ABORT << 16) {
 			scsi_done(chip->srb);
 		} else {
 SkipForAbort:
 			printk(KERN_ERR "scsi command aborted\n");
 		}
-		
+
 		if (rtsx_chk_stat(chip, RTSX_STAT_ABORT)) {
 			complete(&(dev->notify));
-			
+
 			rtsx_set_stat(chip, RTSX_STAT_IDLE);
 		}
 
-		
+
 		chip->srb = NULL;
 		scsi_unlock(host);
 
-		
-		mutex_unlock(&dev->dev_mutex);
-	} 
 
-	/* notify the exit routine that we're actually exiting now 
+		mutex_unlock(&dev->dev_mutex);
+	}
+
+	/* notify the exit routine that we're actually exiting now
 	 *
 	 * complete()/wait_for_completion() is similar to up()/down(),
 	 * except that complete() is safe in the case where the structure
@@ -547,7 +547,7 @@ static int rtsx_polling_thread(void * __dev)
 	struct rtsx_chip *chip = dev->chip;
 	struct sd_info *sd_card = &(chip->sd_card);
 	struct ms_info *ms_card = &(chip->ms_card);
-	
+
 	sd_card->cleanup_counter = 0;
 	ms_card->cleanup_counter = 0;
 
@@ -556,26 +556,26 @@ static int rtsx_polling_thread(void * __dev)
 	for(;;) {
 		wait_timeout(POLLING_INTERVAL);
 
-		
+
 		mutex_lock(&(dev->dev_mutex));
 
-		
+
 		if (rtsx_chk_stat(chip, RTSX_STAT_DISCONNECT)) {
 			printk(KERN_INFO "-- rtsx-polling exiting\n");
 			mutex_unlock(&dev->dev_mutex);
 			break;
 		}
-		
-		mutex_unlock(&dev->dev_mutex);		
+
+		mutex_unlock(&dev->dev_mutex);
 
 		mspro_polling_format_status(chip);
-		
-		
+
+
 		mutex_lock(&(dev->dev_mutex));
 
 		rtsx_polling_func(chip);
 
-		
+
 		mutex_unlock(&dev->dev_mutex);
 	}
 
@@ -615,7 +615,7 @@ static irqreturn_t rtsx_interrupt(int irq, void *dev_id)
 	}
 
 	status = chip->int_reg;
-	
+
 	if (dev->check_card_cd) {
 		if (!(dev->check_card_cd & status)) {
 			dev->trans_result = TRANS_RESULT_FAIL;
@@ -658,7 +658,7 @@ Exit:
 static void rtsx_release_resources(struct rtsx_dev *dev)
 {
 	printk(KERN_INFO "-- %s\n", __FUNCTION__);
-	
+
 	/* Tell the control thread to exit.  The SCSI host must
 	 * already have been removed so it won't try to queue
 	 * any more commands.
@@ -673,7 +673,7 @@ static void rtsx_release_resources(struct rtsx_dev *dev)
 	wait_timeout(200);
 
 	if (dev->rtsx_resv_buf) {
-		dma_free_coherent(&(dev->pci->dev), RTSX_RESV_BUF_LEN, 
+		dma_free_coherent(&(dev->pci->dev), RTSX_RESV_BUF_LEN,
 				dev->rtsx_resv_buf, dev->rtsx_resv_buf_addr);
 		dev->chip->host_cmds_ptr = NULL;
 		dev->chip->host_sg_tbl_ptr = NULL;
@@ -688,7 +688,7 @@ static void rtsx_release_resources(struct rtsx_dev *dev)
 
 	pci_disable_device(dev->pci);
 	pci_release_regions(dev->pci);
-	
+
 	rtsx_release_chip(dev->chip);
 	kfree(dev->chip);
 }
@@ -710,7 +710,7 @@ static void quiesce_and_remove_host(struct rtsx_dev *dev)
 	wake_up(&dev->delay_wait);
 	wait_for_completion(&dev->scanning_done);
 
-	
+
 	wait_timeout(100);
 
 	/* queuecommand won't accept any new commands and the control
@@ -726,7 +726,7 @@ static void quiesce_and_remove_host(struct rtsx_dev *dev)
 	}
 	mutex_unlock(&dev->dev_mutex);
 
-	
+
 	scsi_remove_host(host);
 }
 
@@ -746,7 +746,7 @@ static int rtsx_scan_thread(void * __dev)
 	struct rtsx_dev *dev = (struct rtsx_dev *)__dev;
 	struct rtsx_chip *chip = dev->chip;
 
-	
+
 	if (delay_use > 0) {
 		printk(KERN_INFO "%s: waiting for device "
 				"to settle before scanning\n", CR_DRIVER_NAME);
@@ -755,12 +755,12 @@ static int rtsx_scan_thread(void * __dev)
 				delay_use * HZ);
 	}
 
-	
+
 	if (!rtsx_chk_stat(chip, RTSX_STAT_DISCONNECT)) {
 		scsi_scan_host(rtsx_to_host(dev));
 		printk(KERN_INFO "%s: device scan complete\n", CR_DRIVER_NAME);
 
-		
+
 	}
 
 	kthread_complete_and_exit(&dev->scanning_done, 0);
@@ -822,43 +822,43 @@ static void rtsx_init_options(struct rtsx_chip *chip)
 	chip->sd_voltage_switch_delay = 1000;
 	chip->ms_power_class_en = 3;
 
-	chip->sd_400mA_ocp_thd = 1;	
-	chip->sd_800mA_ocp_thd = 5;	
-	
+	chip->sd_400mA_ocp_thd = 1;
+	chip->sd_800mA_ocp_thd = 5;
+
 	chip->card_drive_sel = 0x55;
 	chip->sd30_drive_sel_1v8 = 0x03;
 	chip->sd30_drive_sel_3v3 = 0x01;
-	
+
 	chip->do_delink_before_power_down = 1;
 	chip->auto_power_down = 1;
 	chip->polling_config = 0;
-	
+
 	chip->force_clkreq_0 = 1;
 	chip->ft2_fast_mode = 0;
-	
+
 	chip->sd_timeout = 10000;
 	chip->ms_timeout = 2000;
 	chip->mspro_timeout = 15000;
-	
+
 	chip->power_down_in_ss = 1;
-	
+
 	chip->sdr104_en = 1;
 	chip->sdr50_en = 1;
 	chip->ddr50_en = 1;
-	
+
 	chip->delink_stage1_step = 100;
 	chip->delink_stage2_step = 40;
 	chip->delink_stage3_step = 20;
-	
+
 	chip->auto_delink_in_L1 = 1;
 	chip->blink_led = 1;
 	chip->msi_en = msi_en;
 	chip->hp_watch_bios_hotplug = 0;
 	chip->phy_voltage = 0xFF;
-	
+
 	chip->support_ms_8bit = 1;
 	chip->s3_pwr_off_delay = 1000;
-	
+
 	chip->pre_read_th = PRE_READ_30M;
 	chip->relink_time = 0x08FFFF;
 
@@ -934,10 +934,10 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 		goto errout;
 	}
 
-	printk(KERN_INFO "Original address: 0x%lx, remapped address: 0x%lx\n", 
+	printk(KERN_INFO "Original address: 0x%lx, remapped address: 0x%lx\n",
 			(unsigned long)(dev->addr), (unsigned long)(dev->remap_addr));
 
-	dev->rtsx_resv_buf = dma_alloc_coherent(&(pci->dev), RTSX_RESV_BUF_LEN, 
+	dev->rtsx_resv_buf = dma_alloc_coherent(&(pci->dev), RTSX_RESV_BUF_LEN,
 			&(dev->rtsx_resv_buf_addr), GFP_KERNEL);
 	if (dev->rtsx_resv_buf == NULL) {
 		printk(KERN_ERR "alloc dma buffer fail\n");
@@ -950,17 +950,17 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 	dev->chip->host_sg_tbl_addr = dev->rtsx_resv_buf_addr + HOST_CMDS_BUF_LEN;
 
 	dev->chip->rtsx = dev;
-	
+
 	rtsx_init_options(dev->chip);
 
 	printk(KERN_INFO "pci->irq = %d\n", pci->irq);
-	
+
 	if (dev->chip->msi_en) {
 		if (pci_enable_msi(pci) < 0) {
 			dev->chip->msi_en = 0;
 		}
 	}
-	
+
 	if (rtsx_acquire_irq(dev) < 0) {
 		err = -EBUSY;
 		goto errout;
@@ -974,14 +974,14 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 		printk(KERN_ERR "rtsx_init_chip fail\n");
 		goto errout;
 	}
-	
+
 	err = scsi_add_host(host, &pci->dev);
 	if (err) {
 		printk(KERN_ERR "Unable to add the scsi host\n");
 		goto errout;
 	}
 
-	
+
 	th = kthread_run(rtsx_control_thread, dev, CR_DRIVER_NAME);
 	if (IS_ERR(th)) {
 		printk(KERN_ERR "Unable to start control thread\n");
@@ -990,7 +990,7 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 	}
 	dev->ctl_thread = th;
 
-	
+
 	th = kthread_create(rtsx_scan_thread, dev, "rts5229-scan");
 	if (IS_ERR(th)) {
 		printk(KERN_ERR "Unable to start the device-scanning thread\n");
@@ -1002,7 +1002,7 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 
 	wake_up_process(th);
 
-	
+
 	th = kthread_run(rtsx_polling_thread, dev, "rts5229-polling");
 	if (IS_ERR(th)) {
 		printk(KERN_ERR "Unable to start the device-polling thread\n");
@@ -1016,7 +1016,7 @@ static int  rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 
 	return 0;
 
-	
+
 errout:
 	printk(KERN_ERR "rtsx_probe() failed\n");
 	release_everything(dev);
@@ -1062,7 +1062,7 @@ static struct pci_driver driver = {
 static int __init rts5229_init(void)
 {
 	printk(KERN_INFO "Initializing Realtek PCIE storage driver...\n");
-	
+
 	return pci_register_driver(&driver);
 }
 

--- a/rtsx.h
+++ b/rtsx.h
@@ -56,32 +56,8 @@
 
 #define CR_DRIVER_NAME		"rts5229"
 
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 14)
-#ifdef CONFIG_PCI
-#undef pci_intx
-#define pci_intx(pci,x)
-#endif
-#endif
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24)
-#define sg_page(sg)	(sg)->page
-#endif
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 25)
-#define scsi_set_resid(srb, residue)	((srb)->resid = (residue))
-#define scsi_get_resid(srb)		((srb)->resid)
-
-static inline unsigned scsi_bufflen(struct scsi_cmnd *cmd)
-{
-	return cmd->request_bufflen;
-}
-#endif
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 32)
 #define pci_get_bus_and_slot(bus, devfn)	\
 	pci_get_domain_bus_and_slot(0, (bus), (devfn))
-#endif
 
 /*
  * macros for easy use
@@ -186,38 +162,13 @@ static inline struct rtsx_dev *host_to_rtsx(struct Scsi_Host *host) {
 
 static inline void get_current_time(u8 *timeval_buf, int buf_len)
 {
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
-
-	/*
-	struct timeval {
-	   __kernel_time_t		tv_sec;		// seconds 
-	   __kernel_suseconds_t	tv_usec;	// microseconds
-        };
-	*/
-
-	struct timeval tv;
-#else
 	ktime_t tv;
     	u16 tv_usec;
-#endif
 
 	if (!timeval_buf || (buf_len < 8)) {
 		return;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
-	do_gettimeofday(&tv);
-
-	timeval_buf[0] = (u8)(tv.tv_sec >> 24);
-	timeval_buf[1] = (u8)(tv.tv_sec >> 16);
-	timeval_buf[2] = (u8)(tv.tv_sec >> 8);
-	timeval_buf[3] = (u8)(tv.tv_sec);
-	timeval_buf[4] = (u8)(tv.tv_usec >> 24);
-	timeval_buf[5] = (u8)(tv.tv_usec >> 16);
-	timeval_buf[6] = (u8)(tv.tv_usec >> 8);
-	timeval_buf[7] = (u8)(tv.tv_usec);
-#else
 	tv = ktime_get_real();   // equals to tv.tv_sec
 	tv_usec = ktime_to_us(tv);   // equals to tv.tv_usec
 	timeval_buf[0] = (u8)(tv >> 24);
@@ -228,7 +179,6 @@ static inline void get_current_time(u8 *timeval_buf, int buf_len)
 	timeval_buf[5] = (u8)(tv_usec >> 16);
 	timeval_buf[6] = (u8)(tv_usec >> 8);
 	timeval_buf[7] = (u8)(tv_usec);
-#endif
 }
 
 /* The scsi_lock() and scsi_unlock() macros protect the sm_state and the

--- a/rtsx.h
+++ b/rtsx.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -115,28 +115,28 @@ struct rtsx_chip;
 struct rtsx_dev {
 	struct pci_dev 		*pci;
 
-	
+
 	unsigned long 		addr;
 	void __iomem 		*remap_addr;
 	int 			irq;
 
-	
+
 	spinlock_t 		reg_lock;
-	
-	struct task_struct	*ctl_thread;	 
-	struct task_struct	*polling_thread; 
 
-	
-	struct completion	cmnd_ready;	 
-	struct completion	control_exit;	 
-	struct completion	polling_exit;	 
-	struct completion	notify;		 
-	struct completion	scanning_done;	 
+	struct task_struct	*ctl_thread;
+	struct task_struct	*polling_thread;
 
-	wait_queue_head_t	delay_wait;	 
+
+	struct completion	cmnd_ready;
+	struct completion	control_exit;
+	struct completion	polling_exit;
+	struct completion	notify;
+	struct completion	scanning_done;
+
+	wait_queue_head_t	delay_wait;
 	struct mutex		dev_mutex;
 
-	
+
 	void 			*rtsx_resv_buf;
 	dma_addr_t 		rtsx_resv_buf_addr;
 
@@ -144,7 +144,7 @@ struct rtsx_dev {
 	char			trans_state;
 
 	struct completion 	*done;
-	
+
 	u32 			check_card_cd;
 
 	struct rtsx_chip 	*chip;
@@ -210,5 +210,5 @@ static inline void GetHostASPM(struct rtsx_chip *chip, u8 *val)
 
 int rtsx_read_pci_cfg_byte(u8 bus, u8 dev, u8 func, u8 offset, u8 *val);
 
-#endif  
+#endif
 

--- a/rtsx_card.c
+++ b/rtsx_card.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -63,14 +63,14 @@ void do_remaining_work(struct rtsx_chip *chip)
 #ifdef MS_DELAY_WRITE
 			if (ms_card->delay_write.delay_write_flag) {
 				rtsx_set_stat(chip, RTSX_STAT_RUN);
-				ms_card->cleanup_counter ++; 
+				ms_card->cleanup_counter ++;
 			} else {
 				ms_card->cleanup_counter = 0;
 			}
 #endif
 		}
 	}
-	
+
 	if (sd_card->cleanup_counter > POLLING_WAIT_CNT) {
 		sd_cleanup_work(chip);
 	}
@@ -83,21 +83,21 @@ void do_remaining_work(struct rtsx_chip *chip)
 void do_reset_sd_card(struct rtsx_chip *chip)
 {
 	int retval;
-	
-	RTSX_DEBUGP(("%s: %d, card2lun = 0x%x\n", __FUNCTION__, 
+
+	RTSX_DEBUGP(("%s: %d, card2lun = 0x%x\n", __FUNCTION__,
 		     chip->sd_reset_counter, chip->card2lun[SD_CARD]));
-	
+
 	if (chip->card2lun[SD_CARD] >= MAX_ALLOWED_LUN_CNT) {
 		clear_bit(SD_NR, &(chip->need_reset));
 		chip->sd_reset_counter = 0;
 		chip->sd_show_cnt = 0;
 		return;
 	}
-	
+
 	chip->rw_fail_cnt[chip->card2lun[SD_CARD]] = 0;
-	
+
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	retval = reset_sd_card(chip);
 	if (chip->need_release & SD_CARD) {
 		return;
@@ -133,21 +133,21 @@ void do_reset_sd_card(struct rtsx_chip *chip)
 void do_reset_ms_card(struct rtsx_chip *chip)
 {
 	int retval;
-	
-	RTSX_DEBUGP(("%s: %d, card2lun = 0x%x\n", __FUNCTION__, 
+
+	RTSX_DEBUGP(("%s: %d, card2lun = 0x%x\n", __FUNCTION__,
 		     chip->ms_reset_counter, chip->card2lun[MS_CARD]));
-	
+
 	if (chip->card2lun[MS_CARD] >= MAX_ALLOWED_LUN_CNT) {
 		clear_bit(MS_NR, &(chip->need_reset));
 		chip->ms_reset_counter = 0;
 		chip->ms_show_cnt = 0;
 		return;
 	}
-	
+
 	chip->rw_fail_cnt[chip->card2lun[MS_CARD]] = 0;
-	
+
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	retval = reset_ms_card(chip);
 	if (chip->need_release & MS_CARD) {
 		return;
@@ -176,7 +176,7 @@ void do_reset_ms_card(struct rtsx_chip *chip)
 			card_power_off(chip, MS_CARD);
 		}
 		disable_card_clock(chip, MS_CARD);
-	}	
+	}
 }
 
 void rtsx_power_off_card(struct rtsx_chip *chip)
@@ -185,7 +185,7 @@ void rtsx_power_off_card(struct rtsx_chip *chip)
 		sd_cleanup_work(chip);
 		sd_power_off_card3v3(chip);
 	}
-	
+
 	if (chip->card_ready & MS_CARD) {
 		ms_cleanup_work(chip);
 		ms_power_off_card3v3(chip);
@@ -195,14 +195,14 @@ void rtsx_power_off_card(struct rtsx_chip *chip)
 void rtsx_release_cards(struct rtsx_chip *chip)
 {
 	chip->int_reg = rtsx_readl(chip, RTSX_BIPR);
-	
+
 	if (chip->card_ready & SD_CARD) {
 		if (chip->int_reg & SD_EXIST) {
 			sd_cleanup_work(chip);
 		}
 		release_sd_card(chip);
-	} 
-	
+	}
+
 	if (chip->card_ready & MS_CARD) {
 		if (chip->int_reg & MS_EXIST) {
 			ms_cleanup_work(chip);
@@ -218,7 +218,7 @@ void rtsx_reset_cards(struct rtsx_chip *chip)
 	}
 
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	rtsx_force_power_on(chip, SSC_PDCTL | OC_PDCTL);
 
 	rtsx_enter_work_state(chip);
@@ -235,7 +235,7 @@ void rtsx_reset_cards(struct rtsx_chip *chip)
 	}
 	if (chip->need_reset & MS_CARD) {
 		chip->card_exist |= MS_CARD;
-		
+
 		if (chip->ms_show_cnt >= MAX_SHOW_CNT) {
 			do_reset_ms_card(chip);
 		} else {
@@ -272,7 +272,7 @@ void rtsx_reinit_cards(struct rtsx_chip *chip, int reset_chip)
 		chip->card_exist |= MS_CARD;
 		do_reset_ms_card(chip);
 	}
-	
+
 	chip->need_reinit = 0;
 }
 
@@ -280,9 +280,9 @@ void rtsx_reinit_cards(struct rtsx_chip *chip, int reset_chip)
 void card_cd_debounce(struct rtsx_chip *chip, unsigned long *need_reset, unsigned long *need_release)
 {
 	u8 release_map = 0, reset_map = 0;
-	
+
 	chip->int_reg = rtsx_readl(chip, RTSX_BIPR);
-	
+
 	if (chip->card_exist) {
 		if (chip->card_exist & SD_CARD) {
 			if (!(chip->int_reg & SD_EXIST)) {
@@ -300,14 +300,14 @@ void card_cd_debounce(struct rtsx_chip *chip, unsigned long *need_reset, unsigne
 			reset_map |= MS_CARD;
 		}
 	}
-	
+
 	if (reset_map) {
 		int sd_cnt = 0, ms_cnt = 0;
 		int i;
-		
+
 		for (i = 0; i < (DEBOUNCE_CNT); i++) {
 			chip->int_reg = rtsx_readl(chip, RTSX_BIPR);
-			
+
 			if (chip->int_reg & SD_EXIST) {
 				sd_cnt ++;
 			} else {
@@ -320,7 +320,7 @@ void card_cd_debounce(struct rtsx_chip *chip, unsigned long *need_reset, unsigne
 			}
 			wait_timeout(30);
 		}
-		
+
 		reset_map = 0;
 		if (!(chip->card_exist & SD_CARD) && (sd_cnt > (DEBOUNCE_CNT-1))) {
 			reset_map |= SD_CARD;
@@ -329,7 +329,7 @@ void card_cd_debounce(struct rtsx_chip *chip, unsigned long *need_reset, unsigne
 			reset_map |= MS_CARD;
 		}
 	}
-	
+
 	if (need_reset) {
 		*need_reset = reset_map;
 	}
@@ -350,7 +350,7 @@ void rtsx_init_cards(struct rtsx_chip *chip)
 #ifdef DISABLE_CARD_INT
 	card_cd_debounce(chip, &(chip->need_reset), &(chip->need_release));
 #endif
-	
+
 	if (chip->need_release) {
 		if (!(chip->card_exist & SD_CARD)) {
 			clear_bit(SD_NR, &(chip->need_release));
@@ -388,7 +388,7 @@ void rtsx_init_cards(struct rtsx_chip *chip)
 			CLR_BIT(chip->lun_mc, chip->card2lun[SD_CARD]);
 			chip->rw_fail_cnt[chip->card2lun[SD_CARD]] = 0;
 			rtsx_write_register(chip, RBCTL, RB_FLUSH, RB_FLUSH);
-			
+
 			release_sd_card(chip);
 		}
 
@@ -399,7 +399,7 @@ void rtsx_init_cards(struct rtsx_chip *chip)
 			chip->card_fail &= ~MS_CARD;
 			CLR_BIT(chip->lun_mc, chip->card2lun[MS_CARD]);
 			chip->rw_fail_cnt[chip->card2lun[MS_CARD]] = 0;
-		
+
 			release_ms_card(chip);
 		}
 
@@ -415,10 +415,10 @@ void rtsx_init_cards(struct rtsx_chip *chip)
 
 		rtsx_reset_cards(chip);
 	}
-	
+
 	if (chip->need_reinit) {
 		RTSX_DEBUGP(("chip->need_reinit = 0x%x\n", (unsigned int)(chip->need_reinit)));
-		
+
 		rtsx_reinit_cards(chip, 0);
 	}
 }
@@ -440,7 +440,7 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 	if (chip->cur_clk == clk) {
 		return STATUS_SUCCESS;
 	}
-	
+
 	min_N = 80;
 	max_N = 208;
 	max_div = CLK_DIV_8;
@@ -453,7 +453,7 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 	}
 
 	RTSX_DEBUGP(("Switch SSC clock to %dMHz (cur_clk = %d)\n", clk, chip->cur_clk));
-	
+
 	if ((clk <= 2) || (N > max_N)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -462,14 +462,14 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 	if (mcu_cnt > 15) {
 		mcu_cnt = 15;
 	}
-	
+
 	div = CLK_DIV_1;
 	while ((N < min_N) && (div < max_div)) {
 		N = (N + 2) * 2 - 2;
 		div ++;
 	}
 	RTSX_DEBUGP(("N = %d, div = %d\n", N, div));
-	
+
 	if (chip->ssc_en) {
 		if (chip->cur_card == SD_CARD) {
 			if (CHK_SD_SDR104(sd_card)) {
@@ -502,7 +502,7 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 		} else {
 			ssc_depth = double_depth(chip->ssc_depth_low_speed);
 		}
-		
+
 		if (ssc_depth) {
 			if (div == CLK_DIV_2) {
 				if (ssc_depth > 1) {
@@ -527,7 +527,7 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 	} else {
 		ssc_depth = 0;
 	}
-	
+
 	RTSX_DEBUGP(("ssc_depth = %d\n", ssc_depth));
 
 	rtsx_init_cmd(chip);
@@ -541,7 +541,7 @@ int switch_ssc_clock(struct rtsx_chip *chip, int clk)
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_VPCLK0_CTL, PHASE_NOT_RESET, 0);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_VPCLK0_CTL, PHASE_NOT_RESET, PHASE_NOT_RESET);
 	}
-	
+
 	retval = rtsx_send_cmd(chip, 0, WAIT_TIME);
 	if (retval < 0) {
 		TRACE_RET(chip, STATUS_ERROR);
@@ -563,7 +563,7 @@ int switch_normal_clock(struct rtsx_chip *chip, int clk)
 	if (chip->cur_clk == clk) {
 		return STATUS_SUCCESS;
 	}
-	
+
 	if (chip->cur_card == SD_CARD) {
 		struct sd_info *sd_card = &(chip->sd_card);
 		if (CHK_SD30_SPEED(sd_card) || CHK_MMC_DDR52(sd_card)) {
@@ -654,7 +654,7 @@ int switch_normal_clock(struct rtsx_chip *chip, int clk)
 	}
 	RTSX_WRITE_REG(chip, CLK_DIV, 0xFF, (div << 4) | mcu_cnt);
 	RTSX_WRITE_REG(chip, CLK_SEL, 0xFF, sel);
-	
+
 	if (sd_vpclk_phase_reset) {
 		udelay(200);
 		RTSX_WRITE_REG(chip, SD_VPCLK0_CTL, PHASE_NOT_RESET, PHASE_NOT_RESET);
@@ -673,7 +673,7 @@ void trans_dma_enable(enum dma_data_direction dir, struct rtsx_chip *chip, u32 b
 	if (pack_size > DMA_1024) {
 		pack_size = DMA_512;
 	}
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, IRQSTAT0, DMA_DONE_INT, DMA_DONE_INT);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, DMATC3, 0xFF, (u8)(byte_cnt >> 24));
@@ -682,10 +682,10 @@ void trans_dma_enable(enum dma_data_direction dir, struct rtsx_chip *chip, u32 b
 	rtsx_add_cmd(chip, WRITE_REG_CMD, DMATC0, 0xFF, (u8)byte_cnt);
 
 	if (dir == DMA_FROM_DEVICE) {
-		rtsx_add_cmd(chip, WRITE_REG_CMD, DMACTL, 0x03 | DMA_PACK_SIZE_MASK, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, DMACTL, 0x03 | DMA_PACK_SIZE_MASK,
 			     DMA_DIR_FROM_CARD | DMA_EN | pack_size);
 	} else {
-		rtsx_add_cmd(chip, WRITE_REG_CMD, DMACTL, 0x03 | DMA_PACK_SIZE_MASK, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, DMACTL, 0x03 | DMA_PACK_SIZE_MASK,
 			     DMA_DIR_TO_CARD | DMA_EN | pack_size);
 	}
 
@@ -704,7 +704,7 @@ int enable_card_clock(struct rtsx_chip *chip, u8 card)
 	}
 
 	RTSX_WRITE_REG(chip, CARD_CLK_EN, clk_en, clk_en);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -720,14 +720,14 @@ int disable_card_clock(struct rtsx_chip *chip, u8 card)
 	}
 
 	RTSX_WRITE_REG(chip, CARD_CLK_EN, clk_en, 0);
-	
+
 	return STATUS_SUCCESS;
 }
 
 int card_power_on(struct rtsx_chip *chip, u8 card)
 {
 	int retval;
-	
+
 	rtsx_init_cmd(chip);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_PWR_CTL, SD_POWER_MASK, SD_PARTIAL_POWER_ON);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, PWR_GATE_CTRL, LDO3318_PWR_MASK, LDO_SUSPEND);
@@ -735,9 +735,9 @@ int card_power_on(struct rtsx_chip *chip, u8 card)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	udelay(chip->pmos_pwr_on_interval);
-	
+
 	rtsx_init_cmd(chip);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_PWR_CTL, SD_POWER_MASK, SD_POWER_ON);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, PWR_GATE_CTRL, LDO3318_PWR_MASK, LDO_ON);
@@ -745,7 +745,7 @@ int card_power_on(struct rtsx_chip *chip, u8 card)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -754,7 +754,7 @@ int card_power_off(struct rtsx_chip *chip, u8 card)
 	RTSX_WRITE_REG(chip, CARD_PWR_CTL, SD_POWER_MASK | PMOS_STRG_MASK,
 		       SD_POWER_OFF | PMOS_STRG_400mA);
 	RTSX_WRITE_REG(chip, PWR_GATE_CTRL, LDO3318_PWR_MASK, LDO_OFF);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -771,7 +771,7 @@ int card_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 sec_addr, u16 sec
 	for (i = 0; i < 3; i++) {
 		chip->rw_need_retry = 0;
 		chip->rw_retry_cnt = i;
-	
+
 		retval = chip->rw_card[lun](srb, chip, sec_addr, sec_cnt);
 		if (retval != STATUS_SUCCESS) {
 			if (rtsx_check_chip_exist(chip) != STATUS_SUCCESS) {
@@ -789,7 +789,7 @@ int card_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 sec_addr, u16 sec
 			chip->rw_need_retry = 0;
 			break;
 		}
-		
+
 		RTSX_DEBUGP(("Retry RW, (i = %d)\n", i));
 	}
 
@@ -799,7 +799,7 @@ int card_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 sec_addr, u16 sec
 int card_share_mode(struct rtsx_chip *chip, int card)
 {
 	u8 value;
-	
+
 	if (card == SD_CARD) {
 		value = CARD_SHARE_SD;
 	} else if (card == MS_CARD) {
@@ -807,9 +807,9 @@ int card_share_mode(struct rtsx_chip *chip, int card)
 	} else {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, CARD_SHARE_MODE, CARD_SHARE_MASK, value);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -817,10 +817,10 @@ int card_share_mode(struct rtsx_chip *chip, int card)
 int select_card(struct rtsx_chip *chip, int card)
 {
 	int retval;
-	
+
 	if (chip->cur_card != card) {
 		u8 mod;
-		
+
 		if (card == SD_CARD) {
 			mod = SD_MOD_SEL;
 		} else if (card == MS_CARD) {
@@ -830,13 +830,13 @@ int select_card(struct rtsx_chip *chip, int card)
 		}
 		RTSX_WRITE_REG(chip, CARD_SELECT, 0x07, mod);
 		chip->cur_card = card;
-		
+
 		retval =  card_share_mode(chip, card);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -883,7 +883,7 @@ void disable_auto_blink(struct rtsx_chip *chip)
 int detect_card_cd(struct rtsx_chip *chip, int card)
 {
 	u32 card_cd, status;
-	
+
 	if (card == SD_CARD) {
 		card_cd = SD_EXIST;
 	} else if (card == MS_CARD) {
@@ -892,12 +892,12 @@ int detect_card_cd(struct rtsx_chip *chip, int card)
 		RTSX_DEBUGP(("Wrong card type: 0x%x\n", card));
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	status = rtsx_readl(chip, RTSX_BIPR);
 	if (!(status & card_cd)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -960,7 +960,7 @@ u8 get_lun_card(struct rtsx_chip *chip, unsigned int lun)
 void eject_card(struct rtsx_chip *chip, unsigned int lun)
 {
 	do_remaining_work(chip);
-	
+
 	if ((chip->card_ready & chip->lun2card[lun]) == SD_CARD) {
 		release_sd_card(chip);
 		chip->card_ejected |= SD_CARD;

--- a/rtsx_card.h
+++ b/rtsx_card.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -102,28 +102,28 @@
 #define	TYPE_C_DRIVING			0x02
 #define	TYPE_D_DRIVING		        0x03
 
-#define	DDR_FIX_RX_DAT			0x00 
-#define	DDR_VAR_RX_DAT			0x80 
-#define	DDR_FIX_RX_DAT_EDGE		0x00 
-#define	DDR_FIX_RX_DAT_14_DELAY		0x40 
-#define	DDR_FIX_RX_CMD			0x00 
-#define	DDR_VAR_RX_CMD			0x20 
-#define	DDR_FIX_RX_CMD_POS_EDGE		0x00 
-#define	DDR_FIX_RX_CMD_14_DELAY		0x10 
-#define	SD20_RX_POS_EDGE		0x00 
+#define	DDR_FIX_RX_DAT			0x00
+#define	DDR_VAR_RX_DAT			0x80
+#define	DDR_FIX_RX_DAT_EDGE		0x00
+#define	DDR_FIX_RX_DAT_14_DELAY		0x40
+#define	DDR_FIX_RX_CMD			0x00
+#define	DDR_VAR_RX_CMD			0x20
+#define	DDR_FIX_RX_CMD_POS_EDGE		0x00
+#define	DDR_FIX_RX_CMD_14_DELAY		0x10
+#define	SD20_RX_POS_EDGE		0x00
 #define	SD20_RX_14_DELAY		0x08
 #define SD20_RX_SEL_MASK		0x08
 
-#define	DDR_FIX_TX_CMD_DAT		0x00 
-#define	DDR_VAR_TX_CMD_DAT		0x80 
-#define	DDR_FIX_TX_DAT_14_TSU		0x00 
-#define	DDR_FIX_TX_DAT_12_TSU		0x40 
-#define	DDR_FIX_TX_CMD_NEG_EDGE		0x00 
-#define	DDR_FIX_TX_CMD_14_AHEAD		0x20 
+#define	DDR_FIX_TX_CMD_DAT		0x00
+#define	DDR_VAR_TX_CMD_DAT		0x80
+#define	DDR_FIX_TX_DAT_14_TSU		0x00
+#define	DDR_FIX_TX_DAT_12_TSU		0x40
+#define	DDR_FIX_TX_CMD_NEG_EDGE		0x00
+#define	DDR_FIX_TX_CMD_14_AHEAD		0x20
 #define	SD20_TX_NEG_EDGE		0x00
 #define	SD20_TX_14_AHEAD		0x10
 #define SD20_TX_SEL_MASK		0x10
-#define	DDR_VAR_SDCLK_POL_SWAP		0x01 
+#define	DDR_VAR_SDCLK_POL_SWAP		0x01
 
 #define	SD_TRANSFER_START		0x80
 #define	SD_TRANSFER_END			0x40
@@ -134,7 +134,7 @@
 #define	SD_TM_AUTO_WRITE_4		0x02
 #define	SD_TM_AUTO_READ_3		0x05
 #define	SD_TM_AUTO_READ_4		0x06
-#define	SD_TM_CMD_RSP			0x08		
+#define	SD_TM_CMD_RSP			0x08
 #define	SD_TM_AUTO_WRITE_1		0x09
 #define	SD_TM_AUTO_WRITE_2		0x0A
 #define	SD_TM_NORMAL_READ		0x0C
@@ -190,21 +190,21 @@
 #define	SD_NO_CHECK_CRC16		0x40
 #define SD_NO_CHECK_WAIT_CRC_TO		0x20
 #define	SD_WAIT_BUSY_END		0x08
-#define	SD_NO_WAIT_BUSY_END		0x00	
+#define	SD_NO_WAIT_BUSY_END		0x00
 #define	SD_CHECK_CRC7			0x00
 #define	SD_NO_CHECK_CRC7		0x04
 #define	SD_RSP_LEN_0			0x00
-#define	SD_RSP_LEN_6			0x01			
+#define	SD_RSP_LEN_6			0x01
 #define	SD_RSP_LEN_17			0x02
-#define	SD_RSP_TYPE_R0		0x04	 
-#define	SD_RSP_TYPE_R1		0x01	
-#define	SD_RSP_TYPE_R1b		0x09	
-#define	SD_RSP_TYPE_R2		0x02	
-#define	SD_RSP_TYPE_R3		0x05	
-#define	SD_RSP_TYPE_R4		0x05	
-#define	SD_RSP_TYPE_R5		0x01	
-#define	SD_RSP_TYPE_R6		0x01	
-#define	SD_RSP_TYPE_R7		0x01	
+#define	SD_RSP_TYPE_R0		0x04
+#define	SD_RSP_TYPE_R1		0x01
+#define	SD_RSP_TYPE_R1b		0x09
+#define	SD_RSP_TYPE_R2		0x02
+#define	SD_RSP_TYPE_R3		0x05
+#define	SD_RSP_TYPE_R4		0x05
+#define	SD_RSP_TYPE_R5		0x01
+#define	SD_RSP_TYPE_R6		0x01
+#define	SD_RSP_TYPE_R7		0x01
 
 #define	SD_RSP_80CLK_TIMEOUT_EN	    0x01
 
@@ -226,12 +226,12 @@
 #define	WAIT_INT			0x80
 #define	NO_WAIT_INT			0x00
 #define	NO_AUTO_READ_INT_REG		0x00
-#define	AUTO_READ_INT_REG		0x40	
+#define	AUTO_READ_INT_REG		0x40
 #define	MS_CRC16_ERR			0x20
 #define	MS_RDY_TIMEOUT			0x10
 #define	MS_INT_CMDNK			0x08
 #define	MS_INT_BREQ			0x04
-#define	MS_INT_ERR			0x02 
+#define	MS_INT_ERR			0x02
 #define	MS_INT_CED			0x01
 
 #define	MS_TRANSFER_START		0x80
@@ -720,7 +720,7 @@ static inline u32 get_card_size(struct rtsx_chip *chip, unsigned int lun)
 {
 #ifdef SUPPORT_SD_LOCK
 	struct sd_info *sd_card = &(chip->sd_card);
-	
+
 	if ((get_lun_card(chip, lun) == SD_CARD) && (sd_card->sd_lock_status & SD_LOCKED)) {
 		return 0;
 	} else {
@@ -750,7 +750,7 @@ int card_power_off(struct rtsx_chip *chip, u8 card);
 static inline int card_power_off_all(struct rtsx_chip *chip)
 {
 	RTSX_WRITE_REG(chip, CARD_PWR_CTL, 0x0F, 0x0F);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -764,5 +764,5 @@ static inline void rtsx_clear_ms_error(struct rtsx_chip *chip)
 	rtsx_write_register(chip, CARD_STOP, MS_STOP | MS_CLR_ERR, MS_STOP | MS_CLR_ERR);
 }
 
-#endif  
+#endif
 

--- a/rtsx_chip.c
+++ b/rtsx_chip.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -39,7 +39,7 @@
 void rtsx_disable_card_int(struct rtsx_chip *chip)
 {
 	u32 reg = rtsx_readl(chip, RTSX_BIER);
-	
+
 	reg &= ~(SD_INT_EN | MS_INT_EN);
 	rtsx_writel(chip, RTSX_BIER, reg);
 }
@@ -48,9 +48,9 @@ void rtsx_enable_card_int(struct rtsx_chip *chip)
 {
 	u32 reg = rtsx_readl(chip, RTSX_BIER);
 	int i;
-	
+
 	for (i = 0; i <= chip->max_lun; i++) {
-		
+
 		if (chip->lun2card[i] & SD_CARD) {
 			reg |= SD_INT_EN;
 		}
@@ -58,7 +58,7 @@ void rtsx_enable_card_int(struct rtsx_chip *chip)
 			reg |= MS_INT_EN;
 		}
 	}
-	
+
 	rtsx_writel(chip, RTSX_BIER, reg);
 }
 
@@ -70,11 +70,11 @@ void rtsx_enable_bus_int(struct rtsx_chip *chip)
 #endif
 
 	reg = TRANS_OK_INT_EN | TRANS_FAIL_INT_EN | DELINK_INT_EN;
-	
+
 #ifndef DISABLE_CARD_INT
 	for (i = 0; i <= chip->max_lun; i++) {
 		RTSX_DEBUGP(("lun2card[%d] = 0x%02x\n", i, chip->lun2card[i]));
-		
+
 		if (chip->lun2card[i] & SD_CARD) {
 			reg |= SD_INT_EN;
 		}
@@ -92,7 +92,7 @@ void rtsx_enable_bus_int(struct rtsx_chip *chip)
 	}
 
 	rtsx_writel(chip, RTSX_BIER, reg);
-	
+
 	RTSX_DEBUGP(("RTSX_BIER: 0x%08x\n", reg));
 }
 
@@ -114,11 +114,11 @@ static int rtsx_init_pull_ctl(struct rtsx_chip *chip)
 		rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_PULL_CTL3, 0xFF, 0xD5);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_PULL_CTL5, 0xFF, 0x55);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_PULL_CTL6, 0xFF, 0x15);
-	
+
 	retval = rtsx_send_cmd(chip, 0, 100);
 	if (retval < 0)
 		TRACE_RET(chip, STATUS_FAIL);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -129,10 +129,10 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 	rtsx_writel(chip, RTSX_HCBAR, chip->host_cmds_addr);
 
 	rtsx_disable_aspm(chip);
-	
+
 	if (chip->asic_code) {
 		u16 val;
- 		
+
  		retval = rtsx_write_phy_register(chip, 0x00, chip->phy_pcr);
  		if (retval != STATUS_SUCCESS) {
  			TRACE_RET(chip, STATUS_FAIL);
@@ -172,7 +172,7 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 			RTSX_DEBUGP(("Default, chip->phy_voltage = 0x%x\n", chip->phy_voltage));
 		}
 	}
-	
+
 	RTSX_WRITE_REG(chip, HOST_SLEEP_STATE, 0x03, 0x00);
 
 	RTSX_WRITE_REG(chip, CARD_CLK_EN, 0x1E, 0);
@@ -193,9 +193,9 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 #ifdef LED_AUTO_BLINK
 	RTSX_WRITE_REG(chip, OLT_LED_CTL, LED_SHINE_EN | LED_SPEED_MASK, 0x02);
 #endif
-	
+
 	RTSX_WRITE_REG(chip, CHANGE_LINK_STATE, 0x0A, 0);
-	
+
 	RTSX_WRITE_REG(chip, CARD_DRIVE_SEL, 0xFF, chip->card_drive_sel);
 	RTSX_WRITE_REG(chip, SD30_DRIVE_SEL, 0x07, chip->sd30_drive_sel_3v3);
 
@@ -226,38 +226,38 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-	}	
-	
+	}
+
 	retval = rtsx_write_config_byte(chip, 0x81, 1);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = rtsx_write_cfg_dw(chip, 0, 0x70C, 0xFF000000, 0x5B);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, IRQSTAT0, LINK_RDY_INT, LINK_RDY_INT);
 
 	RTSX_WRITE_REG(chip, PERST_GLITCH_WIDTH, 0xFF, 0x80);
-	
+
 	RTSX_WRITE_REG(chip, PWD_SUSPEND_EN, 0xFF, 0xFF);
 	RTSX_WRITE_REG(chip, PWR_GATE_CTRL, PWR_GATE_EN, PWR_GATE_EN);
 
 	rtsx_enable_bus_int(chip);
-	
+
 #ifdef HW_INT_WRITE_CLR
 	RTSX_WRITE_REG(chip, NFTS_TX_CTRL, 0x02, 0);
 #endif
-	
+
 	chip->need_reset = 0;
 
 	chip->int_reg = rtsx_readl(chip, RTSX_BIPR);
 #ifdef HW_INT_WRITE_CLR
 	rtsx_writel(chip, RTSX_BIPR, chip->int_reg);
 #endif
-	
+
 	if (chip->int_reg & SD_EXIST) {
 		chip->need_reset |= SD_CARD;
 	}
@@ -290,7 +290,7 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 	} else {
 		RTSX_WRITE_REG(chip, PETXCFG, 0x08, 0x00);
 	}
-	
+
 	if (CHECK_PID(chip, 0x5227)) {
 		if (chip->ltr_en) {
 			u16 val;
@@ -311,10 +311,10 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 		RTSX_WRITE_REG(chip, CARD_PWR_CTL, 0xFF, MS_PARTIAL_POWER_ON | SD_PARTIAL_POWER_ON);
 		udelay(chip->pmos_pwr_on_interval);
 		RTSX_WRITE_REG(chip, CARD_PWR_CTL, 0xFF, MS_POWER_ON | SD_POWER_ON);
-		
+
 		wait_timeout(200);
 	}
-	
+
 	if (chip->asic_code) {
 		RTSX_WRITE_REG(chip, 0xFE78, 0x03, 0x00);
 		RTSX_WRITE_REG(chip, 0xFE78, 0x03, 0x01);
@@ -329,14 +329,14 @@ int rtsx_reset_chip(struct rtsx_chip *chip)
 	rtsx_reset_detected_cards(chip, 0);
 
 	chip->driver_first_load = 0;
-	
+
 	return STATUS_SUCCESS;
 }
 
 static inline int check_sd_speed_prior(u32 sd_speed_prior)
 {
 	int i, fake_para = 0;
-	
+
 	for (i = 0; i < 4; i++) {
 		u8 tmp = (u8)(sd_speed_prior >> (i*8));
 		if ((tmp < 0x01) || (tmp > 0x04)) {
@@ -344,14 +344,14 @@ static inline int check_sd_speed_prior(u32 sd_speed_prior)
 			break;
 		}
 	}
-	
+
 	return !fake_para;
 }
 
 static inline int check_sd_current_prior(u32 sd_current_prior)
 {
 	int i, fake_para = 0;
-	
+
 	for (i = 0; i < 4; i++) {
 		u8 tmp = (u8)(sd_current_prior >> (i*8));
 		if (tmp > 0x03) {
@@ -359,7 +359,7 @@ static inline int check_sd_current_prior(u32 sd_current_prior)
 			break;
 		}
 	}
-	
+
 	return !fake_para;
 }
 
@@ -412,8 +412,8 @@ static inline int rts5229_auto_load(struct rtsx_chip *chip, u32 relink_time,
 					map_item[i].item.cfg_epcore.func,
 					map_item[i].item.cfg_epcore.mode,
 					map_item[i].item.cfg_epcore.data));
-			
-			retval = rts5229_set_cfg_epcore(chip, autoload_addr, 
+
+			retval = rts5229_set_cfg_epcore(chip, autoload_addr,
 					map_item[i].item.cfg_epcore.cfg_addr,
 					map_item[i].item.cfg_epcore.func,
 					map_item[i].item.cfg_epcore.mode,
@@ -483,7 +483,7 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 	}
 
 	retval = rtsx_read_register(chip, 0xFE90, &val);
-	if (retval != STATUS_SUCCESS)	
+	if (retval != STATUS_SUCCESS)
 		TRACE_RET(chip, STATUS_FAIL);
 	RTSX_DEBUGP(("0xFE90: 0x%x\n", val));
 	chip->ic_version = val & 0x0F;
@@ -505,10 +505,10 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 			DEFAULT_SINGLE,
 		};
 		u8 sd_drive[4] = {
-			0x01,	
-			0x02,	
-			0x05,	
-			0x03	
+			0x01,
+			0x02,
+			0x05,
+			0x03
 		};
 		u8 ssc_depth1[4] = {
 			SSC_DEPTH_512K,
@@ -525,7 +525,7 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 
 		rts5229_init_cfg_epcore(chip, 0x727, 0, val);
 
-		chip->lun_mode = lun_mode[(val >> 6) & 0x03];	
+		chip->lun_mode = lun_mode[(val >> 6) & 0x03];
 		chip->aspm_l0s_l1_en = (val >> 4) & 0x03;
 		chip->sd30_drive_sel_1v8 = sd_drive[(val >> 2) & 0x03];
 		chip->card_drive_sel &= 0x3F;
@@ -547,7 +547,7 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 		val = (u8)(lval >> 8);
 		rts5229_init_cfg_epcore(chip, 0x725, 0, val);
 
-		if ((val & 0xE0) != 0xE0)	
+		if ((val & 0xE0) != 0xE0)
 			chip->asic_sd_sdr104_clk = 206 - ((val >> 5) & 0x07) * 3;
 		if ((val & 0x1C) != 0x1C)
 			chip->asic_sd_sdr50_clk = 98 - ((val >> 2) & 0x07) * 2;
@@ -571,7 +571,7 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 
 		val = (u8)lval;
 		rts5229_init_cfg_epcore(chip, 0x814, 0, val);
-		
+
 		if (chip->auto_delink_en != 2)
 			chip->auto_delink_en = (val & 0x80) ? 1 : 0;
 		chip->sd30_drive_sel_3v3 = sd_drive[(val >> 5) & 0x03];
@@ -579,21 +579,21 @@ static int rtsx_init_from_hw(struct rtsx_chip *chip)
 
 	if (chip->hp_watch_bios_hotplug && CHK_AUTODELINK_EN(chip)) {
 		u8 reg58, reg5b;
-		
+
 		if (rtsx_read_pci_cfg_byte(0x00, 0x1C, 0x02, 0x58, &reg58) < 0) {
 			return STATUS_SUCCESS;
 		}
 		if (rtsx_read_pci_cfg_byte(0x00, 0x1C, 0x02, 0x5B, &reg5b) < 0) {
 			return STATUS_SUCCESS;
 		}
-		
+
 		RTSX_DEBUGP(("reg58 = 0x%x, reg5b = 0x%x\n", reg58, reg5b));
-		
+
 		if ((reg58 == 0x00) && (reg5b == 0x01)) {
 			chip->auto_delink_en = 0;
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -603,25 +603,25 @@ int rtsx_init_chip(struct rtsx_chip *chip)
 	struct ms_info *ms_card = &(chip->ms_card);
 	int retval;
 	unsigned int i;
-	
-	RTSX_DEBUGP(("VID: 0x%04x, PID: 0x%04x, SSVID: 0x%04x, SSDID: 0x%04x\n", 
+
+	RTSX_DEBUGP(("VID: 0x%04x, PID: 0x%04x, SSVID: 0x%04x, SSDID: 0x%04x\n",
 		     chip->vendor_id, chip->product_id, chip->ssvid, chip->ssdid));
-		     
+
 	chip->ic_version = 0;
-	
+
 #ifdef _MSG_TRACE
 	chip->msg_idx = 0;
 #endif
 
 	memset(sd_card, 0, sizeof(struct sd_info));
 	memset(ms_card, 0, sizeof(struct ms_info));
-	
+
 	chip->sd_reset_counter = 0;
 	chip->ms_reset_counter = 0;
-	
+
 	chip->sd_show_cnt = MAX_SHOW_CNT;
 	chip->ms_show_cnt = MAX_SHOW_CNT;
-	
+
 	chip->auto_delink_cnt = 0;
 	chip->auto_delink_allowed = 1;
 	rtsx_set_stat(chip, RTSX_STAT_INIT);
@@ -632,17 +632,17 @@ int rtsx_init_chip(struct rtsx_chip *chip)
 	chip->phy_debug_mode = 0;
 
 	chip->al_map_cnt = 0;
-	
+
 	for (i = 0; i < MAX_ALLOWED_LUN_CNT; i++) {
 		set_sense_type(chip, i, SENSE_TYPE_NO_SENSE);
 		chip->rw_fail_cnt[i] = 0;
 	}
-		     
+
 	if (!check_sd_speed_prior(chip->sd_speed_prior)) {
 		chip->sd_speed_prior = 0x01040203;
 	}
 	RTSX_DEBUGP(("sd_speed_prior = 0x%08x\n", chip->sd_speed_prior));
-	
+
 	if (!check_sd_current_prior(chip->sd_current_prior)) {
 		chip->sd_current_prior = 0x00010203;
 	}
@@ -654,19 +654,19 @@ int rtsx_init_chip(struct rtsx_chip *chip)
 	if ((chip->mmc_ddr_tx_phase > 31) || (chip->mmc_ddr_tx_phase < 0)) {
 		chip->mmc_ddr_tx_phase = 0;
 	}
-	
+
 	RTSX_WRITE_REG(chip, FPDCTL, SSC_POWER_DOWN, 0);
 	udelay(200);
 
 	RTSX_WRITE_REG(chip, CLK_DIV, 0x07, 0x07);
-	
+
 	retval = rtsx_init_from_hw(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	chip->ss_en = 0;
-	
+
 	RTSX_DEBUGP(("chip->asic_code = %d\n", chip->asic_code));
 	RTSX_DEBUGP(("chip->use_hw_setting = %d\n", chip->use_hw_setting));
 	RTSX_DEBUGP(("chip->ic_version = 0x%x\n", chip->ic_version));
@@ -725,7 +725,7 @@ int rtsx_init_chip(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -756,15 +756,15 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 	struct sd_info *sd_card = &(chip->sd_card);
 #endif
 	int ss_allowed;
-	
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_SUSPEND)) {
 		return;
 	}
-	
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_DELINK)) {
 		goto Delink_Stage;
 	}
-	
+
 	if (chip->polling_config) {
 		u8 val;
 		rtsx_read_config_byte(chip, 0, &val);
@@ -773,21 +773,21 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 	if (rtsx_chk_stat(chip, RTSX_STAT_SS)) {
 		return;
 	}
-	
+
 #ifdef SUPPORT_OCP
 	if (chip->ocp_int) {
 		rtsx_read_register(chip, OCPSTAT, &(chip->ocp_stat));
-		
+
 		if (chip->card_exist & SD_CARD) {
 			sd_power_off_card3v3(chip);
 		} else if (chip->card_exist & MS_CARD) {
 			ms_power_off_card3v3(chip);
 		}
-		
+
 		chip->ocp_int = 0;
 	}
 #endif
-		
+
 #ifdef SUPPORT_SD_LOCK
 	if (sd_card->sd_erase_status) {
 		if (chip->card_exist & SD_CARD) {
@@ -805,13 +805,13 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 #endif
 
 	rtsx_init_cards(chip);
-	
+
 	if (chip->ss_en) {
 		ss_allowed = 1;
 	} else {
 		ss_allowed = 0;
 	}
-	
+
 	if (ss_allowed) {
 		if (rtsx_get_stat(chip) != RTSX_STAT_IDLE) {
 			chip->ss_counter = 0;
@@ -824,7 +824,7 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 			}
 		}
 	}
-	
+
 	if (chip->idle_counter < IDLE_MAX_COUNT) {
 		chip->idle_counter ++;
 	} else {
@@ -838,13 +838,13 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 			chip->led_toggle_counter = 0;
 #endif
 			rtsx_force_power_on(chip, SSC_PDCTL);
-			
+
 			if (chip->led_always_on && chip->card_ready && chip->blink_led) {
 				turn_on_led(chip);
 			} else {
 				turn_off_led(chip);
 			}
-			
+
 			if (chip->auto_power_down && !chip->card_ready) {
 				rtsx_force_power_down(chip, SSC_PDCTL | OC_PDCTL);
 			}
@@ -855,12 +855,12 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 	case RTSX_STAT_RUN:
 #ifndef LED_AUTO_BLINK
 		rtsx_blink_led(chip);
-#endif 
+#endif
 		do_remaining_work(chip);
 		break;
 
 	case RTSX_STAT_IDLE:
-		rtsx_enable_aspm(chip);	
+		rtsx_enable_aspm(chip);
 
 		if (chip->ltr_enabled)
 			rtsx_write_register(chip, LTR_CTL, 0xFF, 0x83);
@@ -870,7 +870,7 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 		break;
 	}
 
-	
+
 #ifdef SUPPORT_OCP
 	if (chip->ocp_stat & (SD_OC_NOW | SD_OC_EVER)) {
 		RTSX_DEBUGP(("Over current, OCPSTAT is 0x%x\n", chip->ocp_stat));
@@ -886,19 +886,19 @@ void rtsx_polling_func(struct rtsx_chip *chip)
 #endif
 
 Delink_Stage:
-	if (CHK_AUTODELINK_EN(chip) && chip->auto_delink_allowed && 
+	if (CHK_AUTODELINK_EN(chip) && chip->auto_delink_allowed &&
 			!chip->card_ready && !chip->card_ejected) {
 		int enter_L1 = chip->auto_delink_in_L1 && (chip->aspm_l0s_l1_en || chip->ss_en);
 		int delink_stage1_cnt = chip->delink_stage1_step;
 		int delink_stage2_cnt = delink_stage1_cnt + chip->delink_stage2_step;
 		int delink_stage3_cnt = delink_stage2_cnt + chip->delink_stage3_step;
-		
+
 		if (chip->auto_delink_cnt <= delink_stage3_cnt) {
 			if (chip->auto_delink_cnt == delink_stage1_cnt) {
 				rtsx_set_stat(chip, RTSX_STAT_DELINK);
-				
+
 				clear_first_install_mark(chip);
-				
+
 				if (chip->card_exist) {
 					RTSX_DEBUGP(("False card inserted, do force delink\n"));
 
@@ -910,11 +910,11 @@ Delink_Stage:
 					if (enter_L1) {
 						rtsx_enter_L1(chip);
 					}
-					
+
 					chip->auto_delink_cnt = delink_stage3_cnt + 1;
 				} else {
 					RTSX_DEBUGP(("No card inserted, do delink\n"));
-                
+
 					if (enter_L1) {
 						rtsx_write_register(chip, HOST_SLEEP_STATE, 0x03, 1);
 					}
@@ -923,7 +923,7 @@ Delink_Stage:
 					RTSX_DEBUGP(("RTSX_BIPR: 0x%x\n", rtsx_readl(chip, RTSX_BIPR)));
 #endif
 					rtsx_write_register(chip, CHANGE_LINK_STATE, 0x02, 0x02);
-					
+
 					if (enter_L1) {
 						rtsx_enter_L1(chip);
 					}
@@ -932,17 +932,17 @@ Delink_Stage:
 
 			if (chip->auto_delink_cnt == delink_stage2_cnt) {
 				RTSX_DEBUGP(("Try to do force delink\n"));
-				
+
 				if (enter_L1) {
 					rtsx_exit_L1(chip);
 				}
-				
+
 				rtsx_write_register(chip, CHANGE_LINK_STATE, 0x0A, 0x0A);
 			}
-			
+
 			if (chip->auto_delink_cnt == delink_stage3_cnt) {
 			}
-			
+
 			chip->auto_delink_cnt ++;
 		}
 	} else {
@@ -962,12 +962,12 @@ void rtsx_undo_delink(struct rtsx_chip *chip)
  * @card: flash card type
  *
  * Stop command transfer and DMA transfer.
- * This function is called in error handler. 
+ * This function is called in error handler.
  */
 void rtsx_stop_cmd(struct rtsx_chip *chip, int card)
 {
 	int i;
-	
+
 	for (i = 0; i <= 8; i++) {
 		int addr = RTSX_HCBAR + i * 4;
 		u32 reg;
@@ -976,7 +976,7 @@ void rtsx_stop_cmd(struct rtsx_chip *chip, int card)
 	}
 	rtsx_writel(chip, RTSX_HCBCTLR, STOP_CMD);
 	rtsx_writel(chip, RTSX_HDBCTLR, STOP_DMA);
-	
+
 	for (i = 0; i < 16; i++) {
 		u16 addr = 0xFE20 + (u16)i;
 		u8 val;
@@ -1049,7 +1049,7 @@ int rtsx_write_cfg_dw(struct rtsx_chip *chip, u8 func_no, u16 addr, u32 mask, u3
 {
 	u8 mode = 0, tmp;
 	int i;
-	
+
 
 	for (i = 0; i < 4; i++) {
 		if (mask & 0xFF) {
@@ -1073,7 +1073,7 @@ int rtsx_write_cfg_dw(struct rtsx_chip *chip, u8 func_no, u16 addr, u32 mask, u3
 			}
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1082,7 +1082,7 @@ int rtsx_read_cfg_dw(struct rtsx_chip *chip, u8 func_no, u16 addr, u32 *val)
 	int i;
 	u8 tmp;
 	u32 data = 0;
-	
+
 
 	RTSX_WRITE_REG(chip, CFGADDR0, 0xFF, (u8)addr);
 	RTSX_WRITE_REG(chip, CFGADDR1, 0xFF, (u8)(addr >> 8));
@@ -1103,7 +1103,7 @@ int rtsx_read_cfg_dw(struct rtsx_chip *chip, u8 func_no, u16 addr, u32 *val)
 	if (val) {
 		*val = data;
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1114,33 +1114,33 @@ int rtsx_write_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int l
 	u16 aligned_addr = addr - offset;
 	int dw_len, i, j;
 	int retval;
-	
+
 	RTSX_DEBUGP(("%s\n", __FUNCTION__));
-	
+
 	if (!buf) {
 		TRACE_RET(chip, STATUS_NOMEM);
 	}
-	
+
 	if ((len + offset) % 4) {
 		dw_len = (len + offset) / 4 + 1;
 	} else {
 		dw_len = (len + offset) / 4;
 	}
 	RTSX_DEBUGP(("dw_len = %d\n", dw_len));
-	
+
 	data = (u32 *)vmalloc(dw_len * 4);
 	if (!data) {
 		TRACE_RET(chip, STATUS_NOMEM);
 	}
 	memset(data, 0, dw_len * 4);
-	
+
 	mask = (u32 *)vmalloc(dw_len * 4);
 	if (!mask) {
 		vfree(data);
 		TRACE_RET(chip, STATUS_NOMEM);
 	}
 	memset(mask, 0, dw_len * 4);
-	
+
 	j = 0;
 	for (i = 0; i < len; i++) {
 		mask[j] |= 0xFF << (offset * 8);
@@ -1150,10 +1150,10 @@ int rtsx_write_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int l
 			offset = 0;
 		}
 	}
-	
+
 	RTSX_DUMP(mask, dw_len * 4);
 	RTSX_DUMP(data, dw_len * 4);
-	
+
 	for (i = 0; i < dw_len; i++) {
 		retval = rtsx_write_cfg_dw(chip, func, aligned_addr + i * 4, mask[i], data[i]);
 		if (retval != STATUS_SUCCESS) {
@@ -1162,10 +1162,10 @@ int rtsx_write_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int l
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	vfree(data);
 	vfree(mask);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1176,21 +1176,21 @@ int rtsx_read_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int le
 	u16 aligned_addr = addr - offset;
 	int dw_len, i, j;
 	int retval;
-	
+
 	RTSX_DEBUGP(("%s\n", __FUNCTION__));
-	
+
 	if ((len + offset) % 4) {
 		dw_len = (len + offset) / 4 + 1;
 	} else {
 		dw_len = (len + offset) / 4;
 	}
 	RTSX_DEBUGP(("dw_len = %d\n", dw_len));
-	
+
 	data = (u32 *)vmalloc(dw_len * 4);
 	if (!data) {
 		TRACE_RET(chip, STATUS_NOMEM);
 	}
-	
+
 	for (i = 0; i < dw_len; i++) {
 		retval = rtsx_read_cfg_dw(chip, func, aligned_addr + i * 4, data + i);
 		if (retval != STATUS_SUCCESS) {
@@ -1198,10 +1198,10 @@ int rtsx_read_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int le
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	if (buf) {
 		j = 0;
-		
+
 		for (i = 0; i < len; i++) {
 			buf[i] = (u8)(data[j] >> (offset * 8));
 			if (++offset == 4) {
@@ -1210,9 +1210,9 @@ int rtsx_read_cfg_seq(struct rtsx_chip *chip, u8 func, u16 addr, u8 *buf, int le
 			}
 		}
 	}
-	
+
 	vfree(data);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1234,11 +1234,11 @@ int rtsx_write_phy_register(struct rtsx_chip *chip, u8 addr, u16 val)
 			break;
 		}
 	}
-	
+
 	if (!finished) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1258,7 +1258,7 @@ int rtsx_read_phy_register(struct rtsx_chip *chip, u8 addr, u16 *val)
 			break;
 		}
 	}
-	
+
 	if (!finished) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -1271,7 +1271,7 @@ int rtsx_read_phy_register(struct rtsx_chip *chip, u8 addr, u16 *val)
 	if (val) {
 		*val = data;
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1279,7 +1279,7 @@ int rtsx_clr_phy_reg_bit(struct rtsx_chip *chip, u8 reg, u8 bit)
 {
 	int retval;
 	u16 value;
-	
+
 	retval = rtsx_read_phy_register(chip, reg, &value);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1291,7 +1291,7 @@ int rtsx_clr_phy_reg_bit(struct rtsx_chip *chip, u8 reg, u8 bit)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1299,7 +1299,7 @@ int rtsx_set_phy_reg_bit(struct rtsx_chip *chip, u8 reg, u8 bit)
 {
 	int retval;
 	u16 value;
-	
+
 	retval = rtsx_read_phy_register(chip, reg, &value);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1311,7 +1311,7 @@ int rtsx_set_phy_reg_bit(struct rtsx_chip *chip, u8 reg, u8 bit)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1320,7 +1320,7 @@ int rtsx_check_link_ready(struct rtsx_chip *chip)
 	u8 val;
 
 	RTSX_READ_REG(chip, IRQSTAT0, &val);
-	
+
 	RTSX_DEBUGP(("IRQSTAT0: 0x%x\n", val));
 	if (val & LINK_RDY_INT) {
 		RTSX_DEBUGP(("Delinked!\n"));
@@ -1336,7 +1336,7 @@ int rtsx_check_link_ready(struct rtsx_chip *chip)
 static void rtsx_handle_pm_dstate(struct rtsx_chip *chip, u8 dstate)
 {
 	RTSX_DEBUGP(("%04x set pm_dstate to %d\n", chip->product_id, dstate));
-	
+
 	rtsx_write_config_byte(chip, 0x44, dstate);
 	rtsx_write_config_byte(chip, 0x45, 0);
 }
@@ -1355,19 +1355,19 @@ void rtsx_exit_L1(struct rtsx_chip *chip)
 void rtsx_enter_ss(struct rtsx_chip *chip)
 {
 	RTSX_DEBUGP(("Enter Selective Suspend State!\n"));
-	
+
 	rtsx_write_register(chip, IRQSTAT0, LINK_RDY_INT, LINK_RDY_INT);
 
 	if (chip->power_down_in_ss) {
 		rtsx_power_off_card(chip);
-	
+
 		rtsx_force_power_down(chip, SSC_PDCTL | OC_PDCTL);
 	}
 
 	if (CHK_AUTODELINK_EN(chip)) {
 		rtsx_write_register(chip, HOST_SLEEP_STATE, 0x01, 0x01);
 	} else {
-		if (!chip->phy_debug_mode) {		
+		if (!chip->phy_debug_mode) {
 			u32 tmp;
 			tmp = rtsx_readl(chip,RTSX_BIER) ;
 			tmp |= CARD_INT;
@@ -1380,7 +1380,7 @@ void rtsx_enter_ss(struct rtsx_chip *chip)
 	rtsx_enter_L1(chip);
 
 	RTSX_CLR_DELINK(chip);
-	
+
 	rtsx_set_stat(chip, RTSX_STAT_SS);
 }
 
@@ -1415,31 +1415,31 @@ int rtsx_pre_handle_interrupt(struct rtsx_chip *chip)
 
 	ocp_int = SD_OC_INT;
 #endif
-	
+
 	if (chip->ss_en) {
 		chip->ss_counter = 0;
 		if (rtsx_get_stat(chip) == RTSX_STAT_SS) {
 			exit_ss = 1;
 			rtsx_exit_L1(chip);
-			
+
 			rtsx_set_stat(chip, RTSX_STAT_RUN);
 		}
 	}
 
 	int_enable = rtsx_readl(chip, RTSX_BIER);
-	
+
 	chip->int_reg = rtsx_readl(chip, RTSX_BIPR);
 
 #ifdef HW_INT_WRITE_CLR
 	rtsx_writel(chip, RTSX_BIPR, chip->int_reg);
 #endif
-	
+
 	if (((chip->int_reg & int_enable) == 0) || (chip->int_reg == 0xFFFFFFFF)) {
 		return STATUS_FAIL;
 	}
-	
+
 	status = chip->int_reg &= (int_enable | 0x7FFFFF);
-	
+
 	if (status & CARD_INT) {
 		chip->auto_delink_cnt = 0;
 
@@ -1477,34 +1477,34 @@ int rtsx_pre_handle_interrupt(struct rtsx_chip *chip)
 			}
 		}
 	}
-	
+
 #ifdef SUPPORT_OCP
 	chip->ocp_int = ocp_int & status;
 #endif
-	
-	return STATUS_SUCCESS;	
+
+	return STATUS_SUCCESS;
 }
 
 void rtsx_do_before_power_down(struct rtsx_chip *chip, int pm_stat)
 {
 	int retval;
-	
+
 	RTSX_DEBUGP(("rtsx_do_before_power_down, pm_stat = %d\n", pm_stat));
-	
+
 	rtsx_set_stat(chip, RTSX_STAT_SUSPEND);
-	
+
 	retval = rtsx_force_power_on(chip, SSC_PDCTL);
 	if (retval != STATUS_SUCCESS) {
 		return;
 	}
-	
+
 	rtsx_release_cards(chip);
 	rtsx_disable_bus_int(chip);
 	if (chip->blink_led)
 		turn_off_led(chip);
-	
+
 	rtsx_write_register(chip, PETXCFG, 0x08, 0x08);
-	
+
 	if (pm_stat == PM_S1) {
 		RTSX_DEBUGP(("Host enter S1\n"));
 		rtsx_write_register(chip, HOST_SLEEP_STATE, 0x03, HOST_ENTER_S1);
@@ -1515,17 +1515,17 @@ void rtsx_do_before_power_down(struct rtsx_chip *chip, int pm_stat)
 		RTSX_DEBUGP(("Host enter S3\n"));
 		rtsx_write_register(chip, HOST_SLEEP_STATE, 0x03, HOST_ENTER_S3);
 	}
-	
+
 	if (chip->do_delink_before_power_down && CHK_AUTODELINK_EN(chip)) {
 		rtsx_write_register(chip, CHANGE_LINK_STATE, 0x02, 2);
 	}
-	
-	
+
+
 	rtsx_force_power_down(chip, SSC_PDCTL | OC_PDCTL);
-	
+
 	chip->cur_clk = 0;
 	chip->cur_card = 0;
-	
+
 	chip->card_exist = 0;
 }
 
@@ -1535,12 +1535,12 @@ void rtsx_enable_aspm(struct rtsx_chip *chip)
 		if (!chip->aspm_enabled) {
 			RTSX_DEBUGP(("Try to enable ASPM\n"));
 			chip->aspm_enabled = 1;
-			
+
 			if (chip->asic_code) {
 				rtsx_write_phy_register(chip, 0x07, 0);
 			}
 			rtsx_write_config_byte(chip, LCTLR, chip->aspm_l0s_l1_en);
-			
+
 			if (chip->config_host_aspm) {
 				rtsx_set_host_aspm(chip, chip->host_aspm_val);
 			}
@@ -1560,13 +1560,13 @@ void rtsx_disable_aspm(struct rtsx_chip *chip)
 			if (chip->config_host_aspm) {
 				rtsx_disable_host_aspm(chip);
 			}
-			
+
 			rtsx_write_config_byte(chip, LCTLR, 0x00);
 			wait_timeout(1);
 		}
 	}
 
-	return;	
+	return;
 }
 
 void rtsx_enter_work_state(struct rtsx_chip *chip)
@@ -1583,39 +1583,39 @@ int rtsx_read_ppbuf(struct rtsx_chip *chip, u8 *buf, int buf_len)
 	int i;
 	u16 reg_addr;
 	u8 *ptr;
-	
+
 	if (!buf) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
-	
+
 	ptr = buf;
 	reg_addr = PPBUF_BASE2;
 #ifdef USING_PPBUF
 	for (i = 0; i < buf_len/256; i++) {
 		int j;
-		
+
 		rtsx_init_cmd(chip);
-		
+
 		for (j = 0; j < 256; j++) {
 			rtsx_add_cmd(chip, READ_REG_CMD, reg_addr++, 0, 0);
 		}
-		
+
 		retval = rtsx_send_cmd(chip, 0, 250);
 		if (retval < 0) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		memcpy(ptr, rtsx_get_cmd_data(chip), 256);
 		ptr += 256;
 	}
-	
+
 	if (buf_len%256) {
 		rtsx_init_cmd(chip);
-		
+
 		for (i = 0; i < buf_len%256; i++) {
 			rtsx_add_cmd(chip, READ_REG_CMD, reg_addr++, 0, 0);
 		}
-		
+
 		retval = rtsx_send_cmd(chip, 0, 250);
 		if (retval < 0) {
 			TRACE_RET(chip, STATUS_FAIL);
@@ -1623,19 +1623,19 @@ int rtsx_read_ppbuf(struct rtsx_chip *chip, u8 *buf, int buf_len)
 	}
 #else
 	rtsx_init_cmd(chip);
-	
+
 	for (i = 0; i < buf_len%256; i++) {
 		rtsx_add_cmd(chip, READ_REG_CMD, reg_addr++, 0, 0);
 	}
-	
+
 	retval = rtsx_send_cmd(chip, 0, 250);
 	if (retval < 0) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 #endif
-	
+
 	memcpy(ptr, rtsx_get_cmd_data(chip), buf_len%256);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1645,38 +1645,38 @@ int rtsx_write_ppbuf(struct rtsx_chip *chip, u8 *buf, int buf_len)
 	int i;
 	u16 reg_addr;
 	u8 *ptr;
-	
+
 	if (!buf) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
-	
+
 	ptr = buf;
 	reg_addr = PPBUF_BASE2;
 #ifdef USING_PPBUF
 	for (i = 0; i < buf_len/256; i++) {
 		int j;
-		
+
 		rtsx_init_cmd(chip);
-		
+
 		for (j = 0; j < 256; j++) {
 			rtsx_add_cmd(chip, WRITE_REG_CMD, reg_addr++, 0xFF, *ptr);
 			ptr++;
 		}
-		
+
 		retval = rtsx_send_cmd(chip, 0, 250);
 		if (retval < 0) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	if (buf_len%256) {
 		rtsx_init_cmd(chip);
-		
+
 		for (i = 0; i < buf_len%256; i++) {
 			rtsx_add_cmd(chip, WRITE_REG_CMD, reg_addr++, 0xFF, *ptr);
 			ptr++;
 		}
-		
+
 		retval = rtsx_send_cmd(chip, 0, 250);
 		if (retval < 0) {
 			TRACE_RET(chip, STATUS_FAIL);
@@ -1684,18 +1684,18 @@ int rtsx_write_ppbuf(struct rtsx_chip *chip, u8 *buf, int buf_len)
 	}
 #else
 	rtsx_init_cmd(chip);
-	
+
 	for (i = 0; i < buf_len%256; i++) {
 		rtsx_add_cmd(chip, WRITE_REG_CMD, reg_addr++, 0xFF, *ptr);
 		ptr++;
 	}
-	
+
 	retval = rtsx_send_cmd(chip, 0, 250);
 	if (retval < 0) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 #endif
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1704,7 +1704,7 @@ int rtsx_check_chip_exist(struct rtsx_chip *chip)
 	if (rtsx_readl(chip, 0) == 0xFFFFFFFF) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1712,24 +1712,24 @@ int rtsx_force_power_on(struct rtsx_chip *chip, u8 ctl)
 {
 	int retval;
 	u8 mask = 0;
-	
+
 	if (ctl & SSC_PDCTL) {
 		mask |= SSC_POWER_DOWN;
 	}
-	
+
 #ifdef SUPPORT_OCP
 	if (ctl & OC_PDCTL) {
 		mask |= SD_OC_POWER_DOWN;
 	}
 #endif
-	
+
 	if (mask) {
 		retval = rtsx_write_register(chip, FPDCTL, mask, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1737,17 +1737,17 @@ int rtsx_force_power_down(struct rtsx_chip *chip, u8 ctl)
 {
 	int retval;
 	u8 mask = 0, val = 0;
-	
+
 	if (ctl & SSC_PDCTL) {
 		mask |= SSC_POWER_DOWN;
 	}
-	
+
 #ifdef SUPPORT_OCP
 	if (ctl & OC_PDCTL) {
 		mask |= SD_OC_POWER_DOWN;
 	}
 #endif
-	
+
 	if (mask) {
 		val = mask;
 		retval = rtsx_write_register(chip, FPDCTL, mask, val);
@@ -1755,7 +1755,7 @@ int rtsx_force_power_down(struct rtsx_chip *chip, u8 ctl)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1763,7 +1763,7 @@ void rtsx_wait_rb_full(struct rtsx_chip *chip)
 {
 	int i;
 	u8 val;
-	
+
 	for (i = 0; i < 1000; i++) {
 		if (rtsx_read_register(chip, RBCTL, &val)) {
 			break;
@@ -1771,7 +1771,7 @@ void rtsx_wait_rb_full(struct rtsx_chip *chip)
 		if (val & RB_FULL) {
 			break;
 		}
-		
+
 		mdelay(1);
 	}
 }
@@ -1781,7 +1781,7 @@ void rtsx_set_stat(struct rtsx_chip *chip, enum RTSX_STAT stat)
 	if (stat != RTSX_STAT_IDLE) {
 		chip->idle_counter = 0;
 	}
-	
+
 	if (chip->rtsx_stat != stat) {
 		chip->rtsx_stat = stat;
 #ifdef LED_AUTO_BLINK

--- a/rtsx_chip.h
+++ b/rtsx_chip.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -32,7 +32,7 @@
 #define SUPPORT_MAGIC_GATE
 #define SUPPORT_MSXC
 #define SUPPORT_SD_LOCK
-#define HW_INT_WRITE_CLR		
+#define HW_INT_WRITE_CLR
 #define LED_AUTO_BLINK
 #define USING_PPBUF
 
@@ -53,7 +53,7 @@
 #define LED_TOGGLE_INTERVAL	6
 #define	GPIO_TOGGLE_THRESHOLD   1024
 
-#define POLLING_INTERVAL	30	
+#define POLLING_INTERVAL	30
 
 #define TRACE_ITEM_CNT		64
 
@@ -86,19 +86,19 @@
  * Transport return codes
  */
 
-#define TRANSPORT_GOOD	   	0   
-#define TRANSPORT_FAILED  	1   
-#define TRANSPORT_NO_SENSE 	2  
-#define TRANSPORT_ERROR   	3   
+#define TRANSPORT_GOOD	   	0
+#define TRANSPORT_FAILED  	1
+#define TRANSPORT_NO_SENSE 	2
+#define TRANSPORT_ERROR   	3
 
 
 /*-----------------------------------
     Start-Stop-Unit
 -----------------------------------*/
-#define STOP_MEDIUM			0x00    
-#define MAKE_MEDIUM_READY		0x01    
-#define UNLOAD_MEDIUM			0x02    
-#define LOAD_MEDIUM			0x03    
+#define STOP_MEDIUM			0x00
+#define MAKE_MEDIUM_READY		0x01
+#define UNLOAD_MEDIUM			0x02
+#define LOAD_MEDIUM			0x03
 
 /*-----------------------------------
     STANDARD_INQUIRY
@@ -114,49 +114,49 @@
 #define CMD_QUE                 0x00
 #define SFT_RE                  0x00
 
-#define VEN_ID_LEN              8               
-#define PRDCT_ID_LEN            16              
-#define PRDCT_REV_LEN           4               
+#define VEN_ID_LEN              8
+#define PRDCT_ID_LEN            16
+#define PRDCT_REV_LEN           4
 
 
 
-#define RTSX_FLIDX_TRANS_ACTIVE		18  
-#define RTSX_FLIDX_ABORTING		20  
-#define RTSX_FLIDX_DISCONNECTING	21  
+#define RTSX_FLIDX_TRANS_ACTIVE		18
+#define RTSX_FLIDX_ABORTING		20
+#define RTSX_FLIDX_DISCONNECTING	21
 #define ABORTING_OR_DISCONNECTING	((1UL << US_FLIDX_ABORTING) | \
 					 (1UL << US_FLIDX_DISCONNECTING))
-#define RTSX_FLIDX_RESETTING		22  
-#define RTSX_FLIDX_TIMED_OUT		23  
+#define RTSX_FLIDX_RESETTING		22
+#define RTSX_FLIDX_TIMED_OUT		23
 
 
 
-#define DRCT_ACCESS_DEV         0x00    
-#define RMB_DISC                0x80    
-#define ANSI_SCSI2              0x02    
+#define DRCT_ACCESS_DEV         0x00
+#define RMB_DISC                0x80
+#define ANSI_SCSI2              0x02
 
-#define SCSI                    0x00    
+#define SCSI                    0x00
 
 
 #define	WRITE_PROTECTED_MEDIA 0x07
 
 
-#define ILI                     0x20    
+#define ILI                     0x20
 
-#define NO_SENSE                0x00    
-#define RECOVER_ERR             0x01    
-#define NOT_READY               0x02    
-#define MEDIA_ERR               0x03    
-#define HARDWARE_ERR            0x04    
-#define ILGAL_REQ               0x05    
-#define UNIT_ATTENTION          0x06    
-#define DAT_PRTCT               0x07    
-#define BLNC_CHK                0x08    
-                                        
-#define CPY_ABRT                0x0a    
-#define ABRT_CMD                0x0b    
-#define EQUAL                   0x0c    
-#define VLM_OVRFLW              0x0d    
-#define MISCMP                  0x0e    
+#define NO_SENSE                0x00
+#define RECOVER_ERR             0x01
+#define NOT_READY               0x02
+#define MEDIA_ERR               0x03
+#define HARDWARE_ERR            0x04
+#define ILGAL_REQ               0x05
+#define UNIT_ATTENTION          0x06
+#define DAT_PRTCT               0x07
+#define BLNC_CHK                0x08
+
+#define CPY_ABRT                0x0a
+#define ABRT_CMD                0x0b
+#define EQUAL                   0x0c
+#define VLM_OVRFLW              0x0d
+#define MISCMP                  0x0e
 
 #define READ_ERR                -1
 #define WRITE_ERR               -2
@@ -168,28 +168,28 @@
     SENSE_DATA
 -----------------------------------*/
 
-#define SENSE_VALID             0x80    
-#define SENSE_INVALID           0x00    
+#define SENSE_VALID             0x80
+#define SENSE_INVALID           0x00
 
 
-#define CUR_ERR                 0x70    
-#define DEF_ERR                 0x71    
+#define CUR_ERR                 0x70
+#define DEF_ERR                 0x71
 
 
-#define SNSKEYINFO_LEN          3       
+#define SNSKEYINFO_LEN          3
 
 #define SKSV                    0x80
 #define CDB_ILLEGAL             0x40
 #define DAT_ILLEGAL             0x00
 #define BPV                     0x08
-#define BIT_ILLEGAL0            0       
-#define BIT_ILLEGAL1            1       
-#define BIT_ILLEGAL2            2       
-#define BIT_ILLEGAL3            3       
-#define BIT_ILLEGAL4            4       
-#define BIT_ILLEGAL5            5       
-#define BIT_ILLEGAL6            6       
-#define BIT_ILLEGAL7            7       
+#define BIT_ILLEGAL0            0
+#define BIT_ILLEGAL1            1
+#define BIT_ILLEGAL2            2
+#define BIT_ILLEGAL3            3
+#define BIT_ILLEGAL4            4
+#define BIT_ILLEGAL5            5
+#define BIT_ILLEGAL6            6
+#define BIT_ILLEGAL7            7
 
 
 #define ASC_NO_INFO             0x00
@@ -220,23 +220,23 @@
 
 
 struct sense_data_t {
-    unsigned char   err_code;			
-							
-							
-							
-							
-							
-							
-    unsigned char   seg_no;			
-    unsigned char   sense_key;			
-							
-    unsigned char   info[4];			
-    unsigned char   ad_sense_len;		
-    unsigned char   cmd_info[4];		
-    unsigned char   asc;			
-    unsigned char   ascq;			
-    unsigned char   rfu;			
-    unsigned char   sns_key_info[3];		
+    unsigned char   err_code;
+
+
+
+
+
+
+    unsigned char   seg_no;
+    unsigned char   sense_key;
+
+    unsigned char   info[4];
+    unsigned char   ad_sense_len;
+    unsigned char   cmd_info[4];
+    unsigned char   asc;
+    unsigned char   ascq;
+    unsigned char   rfu;
+    unsigned char   sns_key_info[3];
 };
 
 
@@ -328,7 +328,7 @@ typedef int (*card_rw_func)(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 s
 
 enum card_clock	{CLK_20 = 1, CLK_30, CLK_40, CLK_50, CLK_60, CLK_80, CLK_100, CLK_120, CLK_150, CLK_200};
 
-enum RTSX_STAT	{RTSX_STAT_INIT, RTSX_STAT_IDLE, RTSX_STAT_RUN, RTSX_STAT_SS, 
+enum RTSX_STAT	{RTSX_STAT_INIT, RTSX_STAT_IDLE, RTSX_STAT_RUN, RTSX_STAT_SS,
 		RTSX_STAT_DELINK, RTSX_STAT_SUSPEND, RTSX_STAT_ABORT, RTSX_STAT_DISCONNECT};
 enum IC_VER	{IC_VER_A, IC_VER_B, IC_VER_C};
 
@@ -339,12 +339,12 @@ enum IC_VER	{IC_VER_A, IC_VER_B, IC_VER_C};
 struct zone_entry {
 	u16 *l2p_table;
 	u16 *free_table;
-	u16 defect_list[MAX_DEFECTIVE_BLOCK];  
+	u16 defect_list[MAX_DEFECTIVE_BLOCK];
 	int set_index;
 	int get_index;
-	int unused_blk_cnt;	
+	int unused_blk_cnt;
 	int disable_count;
-	int build_flag;   
+	int build_flag;
 };
 
 #define TYPE_SD			0x0000
@@ -449,9 +449,9 @@ struct sd_info {
 	int cleanup_counter;
 
 	int sd_clock;
-	
+
 	int mmc_dont_switch_bus;
-	
+
 #ifdef SUPPORT_CPRM
 	int sd_pass_thru_en;
 	int pre_cmd_err;
@@ -468,7 +468,7 @@ struct sd_info {
 
 	u8 sd_switch_fail;
 	u8 sd_read_phase;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	u8 sd_lock_status;
 	u8 sd_erase_status;
@@ -515,7 +515,7 @@ struct ms_info {
 	u32 capacity;
 
 	u8 check_ms_flow;
-	u8 switch_8bit_fail;	
+	u8 switch_8bit_fail;
 	u8 err_code;
 
 	struct zone_entry *segment;
@@ -526,7 +526,7 @@ struct ms_info {
 	u16 progress;
 	u8 raw_sys_info[96];
 	u8 raw_ms_id[16];
-#ifdef SUPPORT_PCGL_1P18	
+#ifdef SUPPORT_PCGL_1P18
 	u8 raw_model_name[48];
 #endif
 
@@ -543,11 +543,11 @@ struct ms_info {
 	int cleanup_counter;
 
 	int ms_clock;
-	
+
 #ifdef SUPPORT_MAGIC_GATE
 	u8 magic_gate_id[16];
 	u8 mg_entry_num;
-	int mg_auth;    
+	int mg_auth;
 #endif
 };
 
@@ -619,44 +619,44 @@ struct rts5229_auto_load_map {
 struct rtsx_chip {
 	rtsx_dev_t 		*rtsx;
 
-	u32 			int_reg;			
+	u32 			int_reg;
 	char 			max_lun;
 	void 			*context;
 
-	void 			*host_cmds_ptr;			
+	void 			*host_cmds_ptr;
 	dma_addr_t		host_cmds_addr;
-	int 			ci;				
+	int 			ci;
 
-	void			*host_sg_tbl_ptr;		
+	void			*host_sg_tbl_ptr;
 	dma_addr_t		host_sg_tbl_addr;
-	int			sgi;				
+	int			sgi;
 
-	struct scsi_cmnd	*srb;		 		
+	struct scsi_cmnd	*srb;
 	struct sense_data_t 	sense_buffer[MAX_ALLOWED_LUN_CNT];
 
-	int			cur_clk;			
-		
+	int			cur_clk;
+
 	int 			cur_card;
-	
-	unsigned long 		need_release;			
-	unsigned long 		need_reset;			
+
+	unsigned long 		need_release;
+	unsigned long 		need_reset;
 	unsigned long 		need_reinit;
-	
+
 	int 			rw_need_retry;
 	int			rw_retry_cnt;
-	
+
 #ifdef SUPPORT_OCP
 	u32 			ocp_int;
 	u8 			ocp_stat;
 #endif
 
-	u8 			card_exist;		
-	u8 			card_ready;		
-	u8 			card_fail;		
-	u8 			card_ejected;		
-	u8 			card_wp;		
+	u8 			card_exist;
+	u8 			card_ready;
+	u8 			card_fail;
+	u8 			card_ejected;
+	u8 			card_wp;
 
-	u8 			lun_mc;			
+	u8 			lun_mc;
 
 #ifndef LED_AUTO_BLINK
 	int 			led_toggle_counter;
@@ -664,7 +664,7 @@ struct rtsx_chip {
 
 	int 			sd_reset_counter;
 	int 			ms_reset_counter;
-	
+
 	u8			card_bus_width[MAX_ALLOWED_LUN_CNT];
 	u32 			capacity[MAX_ALLOWED_LUN_CNT];
 	card_rw_func 		rw_card[MAX_ALLOWED_LUN_CNT];
@@ -672,13 +672,13 @@ struct rtsx_chip {
 	u8			lun2card[MAX_ALLOWED_LUN_CNT];
 
 	int 			rw_fail_cnt[MAX_ALLOWED_LUN_CNT];
-	
+
 	int 			sd_show_cnt;
 	int 			ms_show_cnt;
 
 	struct sd_info		sd_card;
 	struct ms_info		ms_card;
-	
+
 #ifdef _MSG_TRACE
 	struct trace_msg_t	trace_msg[TRACE_ITEM_CNT];
 	int 			msg_idx;
@@ -692,19 +692,19 @@ struct rtsx_chip {
 	u8			host_aspm_val;
 
 	u8 			rtsx_flag;
-	
+
 	int			sd20_mode;
 
 	int 			ss_counter;
 	int 			idle_counter;
 	enum RTSX_STAT 		rtsx_stat;
-	
+
 	u16 			vendor_id;
 	u16			product_id;
 	u16			ssvid;
 	u16			ssdid;
 	u8 			ic_version;
-	
+
 	int			driver_first_load;
 
 	u8 			aspm_level[2];
@@ -714,130 +714,130 @@ struct rtsx_chip {
 
 
 	int adma_mode;
-	
-	int auto_delink_en;		
-	int ss_en;			
-	u8 lun_mode;			
-	u8 aspm_l0s_l1_en;		
-	
-	int power_down_in_ss;		
-	
-	int sdr104_en;			
-	int ddr50_en;			
-	int sdr50_en;			
-	
-	int baro_pkg;			
 
-	int asic_code;			
-	int phy_debug_mode;		
-	int aux_pwr_exist;		
-	u8 ms_power_class_en;		
+	int auto_delink_en;
+	int ss_en;
+	u8 lun_mode;
+	u8 aspm_l0s_l1_en;
 
-	int mspro_formatter_enable;	
+	int power_down_in_ss;
 
-	int use_hw_setting;		
+	int sdr104_en;
+	int ddr50_en;
+	int sdr50_en;
 
-	int remote_wakeup_en;		
+	int baro_pkg;
 
-	int ss_idle_period;		
-	
-	int dynamic_aspm;		
-	int config_host_aspm;		
-	
-	int fpga_sd_sdr104_clk;		
-	int fpga_sd_ddr50_clk;		
-	int fpga_sd_sdr50_clk;		
-	int fpga_sd_hs_clk;		
-	int fpga_mmc_52m_clk;		
-	int fpga_ms_hg_clk;		
-	int fpga_ms_4bit_clk;		
-	int fpga_ms_1bit_clk;		
-	
-	int asic_sd_sdr104_clk;		
-	int asic_sd_ddr50_clk;		
-	int asic_sd_sdr50_clk;		
-	int asic_sd_hs_clk;		
-	int asic_mmc_52m_clk;		
-	int asic_ms_hg_clk;		
-	int asic_ms_4bit_clk;		
-	int asic_ms_1bit_clk;		
-	
-	u8 ssc_depth_sd_sdr104;		
-	u8 ssc_depth_sd_ddr50;		
-	u8 ssc_depth_sd_sdr50;		
-	u8 ssc_depth_sd_hs;		
-	u8 ssc_depth_mmc_52m;		
-	u8 ssc_depth_ms_hg;		
-	u8 ssc_depth_ms_4bit;		
-	u8 ssc_depth_low_speed;		
-	
-	u8 card_drive_sel;		
-	u8 sd30_drive_sel_1v8;		
-	u8 sd30_drive_sel_3v3;		
+	int asic_code;
+	int phy_debug_mode;
+	int aux_pwr_exist;
+	u8 ms_power_class_en;
 
-	u8 sd_400mA_ocp_thd;		
-	u8 sd_800mA_ocp_thd;		
-	
-	int ssc_en;			
-	
-	int msi_en;			
-	
-	int sd_timeout;			
-	int ms_timeout;			
-	int mspro_timeout;		
-	
-	int auto_power_down;		
-	
-	int sd_ddr_tx_phase;  
-	int mmc_ddr_tx_phase; 
-	int sd_default_tx_phase;	
-	int sd_default_rx_phase;	
-	
-	int pmos_pwr_on_interval;	
-	int sd_voltage_switch_delay;	
-	int s3_pwr_off_delay;		
-	
-	int force_clkreq_0;		
-	
-	int ft2_fast_mode;		
-	
+	int mspro_formatter_enable;
+
+	int use_hw_setting;
+
+	int remote_wakeup_en;
+
+	int ss_idle_period;
+
+	int dynamic_aspm;
+	int config_host_aspm;
+
+	int fpga_sd_sdr104_clk;
+	int fpga_sd_ddr50_clk;
+	int fpga_sd_sdr50_clk;
+	int fpga_sd_hs_clk;
+	int fpga_mmc_52m_clk;
+	int fpga_ms_hg_clk;
+	int fpga_ms_4bit_clk;
+	int fpga_ms_1bit_clk;
+
+	int asic_sd_sdr104_clk;
+	int asic_sd_ddr50_clk;
+	int asic_sd_sdr50_clk;
+	int asic_sd_hs_clk;
+	int asic_mmc_52m_clk;
+	int asic_ms_hg_clk;
+	int asic_ms_4bit_clk;
+	int asic_ms_1bit_clk;
+
+	u8 ssc_depth_sd_sdr104;
+	u8 ssc_depth_sd_ddr50;
+	u8 ssc_depth_sd_sdr50;
+	u8 ssc_depth_sd_hs;
+	u8 ssc_depth_mmc_52m;
+	u8 ssc_depth_ms_hg;
+	u8 ssc_depth_ms_4bit;
+	u8 ssc_depth_low_speed;
+
+	u8 card_drive_sel;
+	u8 sd30_drive_sel_1v8;
+	u8 sd30_drive_sel_3v3;
+
+	u8 sd_400mA_ocp_thd;
+	u8 sd_800mA_ocp_thd;
+
+	int ssc_en;
+
+	int msi_en;
+
+	int sd_timeout;
+	int ms_timeout;
+	int mspro_timeout;
+
+	int auto_power_down;
+
+	int sd_ddr_tx_phase;
+	int mmc_ddr_tx_phase;
+	int sd_default_tx_phase;
+	int sd_default_rx_phase;
+
+	int pmos_pwr_on_interval;
+	int sd_voltage_switch_delay;
+	int s3_pwr_off_delay;
+
+	int force_clkreq_0;
+
+	int ft2_fast_mode;
+
 	int do_delink_before_power_down;
-	
-	int polling_config;		
-	
-	int delink_stage1_step;		
-	int delink_stage2_step;		
-	int delink_stage3_step;		
-	
-	int auto_delink_in_L1;		
-	
-	int hp_watch_bios_hotplug;	
-	
-	int support_ms_8bit;		
-	int support_mmc;		
-	
-	u8 blink_led;			
-	u8 led_always_on;		
-	
-	u8 phy_voltage;			
-	
-	u32 sd_speed_prior;		
-	u32 sd_current_prior;		
-	
-	u32 sd_ctl;			
 
-	u32 relink_time;		
-	
-	int pre_read_en;		
-	
-	int pre_read_th;		
+	int polling_config;
 
-	
-	int ltr_en;			
+	int delink_stage1_step;
+	int delink_stage2_step;
+	int delink_stage3_step;
 
-	u16 phy_pcr;			
-	u16 phy_rcr0;			
-	u16 phy_rcr2;			
+	int auto_delink_in_L1;
+
+	int hp_watch_bios_hotplug;
+
+	int support_ms_8bit;
+	int support_mmc;
+
+	u8 blink_led;
+	u8 led_always_on;
+
+	u8 phy_voltage;
+
+	u32 sd_speed_prior;
+	u32 sd_current_prior;
+
+	u32 sd_ctl;
+
+	u32 relink_time;
+
+	int pre_read_en;
+
+	int pre_read_th;
+
+
+	int ltr_en;
+
+	u16 phy_pcr;
+	u16 phy_rcr0;
+	u16 phy_rcr2;
 };
 
 #define rtsx_get_stat(chip)		(chip)->rtsx_stat
@@ -940,5 +940,5 @@ static inline void rtsx_get_host_aspm(struct rtsx_chip *chip, u8 *val)
 	GetHostASPM(chip, val);
 }
 
-#endif  
+#endif
 

--- a/rtsx_chip.h
+++ b/rtsx_chip.h
@@ -315,9 +315,6 @@ struct sense_data_t {
 
 #define SG_INT			0x04
 
-// Commented to remove the redefined variable in /include/linux/blkdev.h
-#define SG_END			0x02
-
 #define SG_VALID		0x01
 
 #define SG_NO_OP		0x00

--- a/rtsx_scsi.c
+++ b/rtsx_scsi.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -132,7 +132,7 @@ void scsi_show_command(struct scsi_cmnd *srb)
 	case VENDOR_CMND: what = "Realtek's vendor command"; break;
 	default: what = "(unknown command)"; unknown_cmd = 1; break;
 	}
-	
+
 	if (srb->cmnd[0] != TEST_UNIT_READY) {
 		RTSX_DEBUGP(("Command %s (%d bytes)\n", what, srb->cmd_len));
 	}
@@ -150,57 +150,57 @@ void set_sense_type(struct rtsx_chip *chip, unsigned int lun, int sense_type)
 	case SENSE_TYPE_MEDIA_CHANGE:
 		set_sense_data(chip, lun, CUR_ERR, 0x06, 0, 0x28, 0, 0, 0);
      		break;
-		
+
     	case SENSE_TYPE_MEDIA_NOT_PRESENT:
 		set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x3A, 0, 0, 0);
     		break;
-		
+
 	case SENSE_TYPE_MEDIA_LBA_OVER_RANGE:
 		set_sense_data(chip, lun, CUR_ERR, 0x05, 0, 0x21, 0, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MEDIA_LUN_NOT_SUPPORT:
 		set_sense_data(chip, lun, CUR_ERR, 0x05, 0, 0x25, 0, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MEDIA_WRITE_PROTECT:
 		set_sense_data(chip, lun, CUR_ERR, 0x07, 0, 0x27, 0, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MEDIA_UNRECOVER_READ_ERR:
 		set_sense_data(chip, lun, CUR_ERR, 0x03, 0, 0x11, 0, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MEDIA_WRITE_ERR:
 		set_sense_data(chip, lun, CUR_ERR, 0x03, 0, 0x0C, 0x02, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MEDIA_INVALID_CMD_FIELD:
-		set_sense_data(chip, lun, CUR_ERR, ILGAL_REQ, 0, 
+		set_sense_data(chip, lun, CUR_ERR, ILGAL_REQ, 0,
 				ASC_INVLD_CDB, ASCQ_INVLD_CDB, CDB_ILLEGAL, 1);
 		break;
-		
+
 	case SENSE_TYPE_FORMAT_IN_PROGRESS:
 		set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_FORMAT_CMD_FAILED:
 		set_sense_data(chip, lun, CUR_ERR, 0x03, 0, 0x31, 0x01, 0, 0);
 		break;
-		
+
 #ifdef SUPPORT_MAGIC_GATE
 	case SENSE_TYPE_MG_KEY_FAIL_NOT_ESTAB:
 		set_sense_data(chip, lun, CUR_ERR, 0x05, 0, 0x6F, 0x02, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MG_KEY_FAIL_NOT_AUTHEN:
 		set_sense_data(chip, lun, CUR_ERR, 0x05, 0, 0x6F, 0x00, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM:
 		set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x30, 0x00, 0, 0);
 		break;
-		
+
 	case SENSE_TYPE_MG_WRITE_ERR:
 		set_sense_data(chip, lun, CUR_ERR, 0x03, 0, 0x0C, 0x00, 0, 0);
 		break;
@@ -219,7 +219,7 @@ void set_sense_type(struct rtsx_chip *chip, unsigned int lun, int sense_type)
 	}
 }
 
-void set_sense_data(struct rtsx_chip *chip, unsigned int lun, u8 err_code, u8 sense_key, 
+void set_sense_data(struct rtsx_chip *chip, unsigned int lun, u8 err_code, u8 sense_key,
 		u32 info, u8 asc, u8 ascq, u8 sns_key_info0, u16 sns_key_info1)
 {
 	struct sense_data_t *sense = &(chip->sense_buffer[lun]);
@@ -255,7 +255,7 @@ static int test_unit_ready(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_CHANGE);
 		return TRANSPORT_FAILED;
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if (get_lun_card(chip, SCSI_LUN(srb)) == SD_CARD) {
 		struct sd_info *sd_card = &(chip->sd_card);
@@ -273,23 +273,23 @@ static int test_unit_ready(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	return TRANSPORT_GOOD;
 }
 
-static unsigned char formatter_inquiry_str[20] = 
+static unsigned char formatter_inquiry_str[20] =
 {
-	'M','E','M','O','R','Y','S','T','I','C','K', 
+	'M','E','M','O','R','Y','S','T','I','C','K',
 #ifdef SUPPORT_MAGIC_GATE
-	'-', 'M', 'G', 
+	'-', 'M', 'G',
 #else
-	0x20, 0x20, 0x20,  
+	0x20, 0x20, 0x20,
 #endif
 
 #ifdef SUPPORT_MAGIC_GATE
-	0x0B,  
+	0x0B,
 #else
-	0x09,  
+	0x09,
 #endif
-	0x00,  
-	0x00,  
-	0x20, 0x20, 0x20, 
+	0x00,
+	0x00,
+	0x20, 0x20, 0x20,
 };
 
 static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -303,9 +303,9 @@ static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	unsigned char *buf;
 	u8 card = get_lun_card(chip, lun);
 	int pro_formatter_flag = 0;
-	unsigned char inquiry_buf[] = 
+	unsigned char inquiry_buf[] =
 	{
-		QULIFIRE|DRCT_ACCESS_DEV, 
+		QULIFIRE|DRCT_ACCESS_DEV,
 		RMB_DISC|0x0D,
 		0x00,
 		0x01,
@@ -314,7 +314,7 @@ static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		0,
 		REL_ADR|WBUS_32|WBUS_16|SYNC|LINKED|CMD_QUE|SFT_RE,
 	};
-	
+
 	switch (GET_LUN_MODE(chip)) {
 	default:
 		inquiry_string = inquiry_default;
@@ -328,13 +328,13 @@ static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		inquiry_string = inquiry_ms;
 		break;
 	}
-	
+
 	buf = vmalloc(scsi_bufflen(srb));
 	if (buf == NULL) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
 	}
 
-	if ((chip->mspro_formatter_enable) && 
+	if ((chip->mspro_formatter_enable) &&
 			(chip->lun2card[lun] & MS_CARD)) {
 		if (!card || (card == MS_CARD)) {
 			pro_formatter_flag = 1;
@@ -365,7 +365,7 @@ static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	} else {
 		memcpy(buf, inquiry_buf, sendbytes);
 	}
-	
+
 	if (pro_formatter_flag) {
 		if (sendbytes > 36) {
 			memcpy(buf + 36, formatter_inquiry_str, sendbytes - 36);
@@ -373,11 +373,11 @@ static int inquiry(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	scsi_set_resid(srb, 0);
-	
+
 	rtsx_stor_set_xfer_buf(buf, scsi_bufflen(srb), srb);
 	vfree(buf);
 
-	return TRANSPORT_GOOD;	
+	return TRANSPORT_GOOD;
 }
 
 
@@ -392,10 +392,10 @@ static int start_stop_unit(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	switch (srb->cmnd[0x4]) {
-	        case STOP_MEDIUM:	
+	        case STOP_MEDIUM:
 			return TRANSPORT_GOOD;
 
-	        case UNLOAD_MEDIUM:	
+	        case UNLOAD_MEDIUM:
 			if (check_card_ready(chip, lun)) {
 				eject_card(chip, lun);
 			}
@@ -437,19 +437,19 @@ static int allow_medium_removal(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 static int request_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 {
 	struct sense_data_t *sense;
-	unsigned int lun = SCSI_LUN(srb);	
+	unsigned int lun = SCSI_LUN(srb);
 	struct ms_info *ms_card = &(chip->ms_card);
 	unsigned char *tmp, *buf;
 
 	sense = &(chip->sense_buffer[lun]);
-	
+
 	if ((get_lun_card(chip, lun) == MS_CARD) && ms_card->pro_under_formatting) {
 		if (ms_card->format_status == FORMAT_SUCCESS) {
 			set_sense_type(chip, lun, SENSE_TYPE_NO_SENSE);
 			ms_card->pro_under_formatting = 0;
 			ms_card->progress = 0;
 		} else if (ms_card->format_status == FORMAT_IN_PROGRESS) {
-			set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04, 
+			set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04,
 					0, (u16)(ms_card->progress));
 		} else {
 			set_sense_type(chip, lun, SENSE_TYPE_FORMAT_CMD_FAILED);
@@ -467,7 +467,7 @@ static int request_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	tmp = (unsigned char *)sense;
 	memcpy(buf, tmp, scsi_bufflen(srb));
-	
+
 	rtsx_stor_set_xfer_buf(buf, scsi_bufflen(srb), srb);
 	vfree(buf);
 
@@ -476,7 +476,7 @@ static int request_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	return TRANSPORT_GOOD;
 }
 
-static void ms_mode_sense(struct rtsx_chip *chip, u8 cmd, 
+static void ms_mode_sense(struct rtsx_chip *chip, u8 cmd,
 		int lun, u8 *buf, int buf_len)
 {
 	struct ms_info *ms_card = &(chip->ms_card);
@@ -484,20 +484,20 @@ static void ms_mode_sense(struct rtsx_chip *chip, u8 cmd,
 	int data_size = buf_len;
 	int support_format = 0;
 	int i = 0;
-	
+
 	if (cmd == MODE_SENSE) {
 		sys_info_offset = 8;
 		if (data_size > 0x68) {
 			data_size = 0x68;
 		}
-		buf[i++] = 0x67;  
+		buf[i++] = 0x67;
 	} else {
 		sys_info_offset = 12;
 		if (data_size > 0x6C) {
 			data_size = 0x6C;
 		}
-		buf[i++] = 0x00;  
-		buf[i++] = 0x6A;  
+		buf[i++] = 0x00;
+		buf[i++] = 0x6A;
 	}
 
 	if (check_card_ready(chip, lun)) {
@@ -510,53 +510,53 @@ static void ms_mode_sense(struct rtsx_chip *chip, u8 cmd,
 		} else {
 			buf[i++] = 0x10;
 		}
-        
+
 		if (check_card_wp(chip, lun)) {
 			buf[i++] = 0x80;
 		} else {
 			buf[i++] = 0x00;
 		}
 	} else {
-		buf[i++] = 0x00;	
-		buf[i++] = 0x00;	
+		buf[i++] = 0x00;
+		buf[i++] = 0x00;
 	}
 
-	buf[i++] = 0x00;		
+	buf[i++] = 0x00;
 
 	if (cmd == MODE_SENSE_10) {
-		buf[i++] = 0x00;  
-		buf[i++] = 0x00;  
-		buf[i++] = 0x00;  
+		buf[i++] = 0x00;
+		buf[i++] = 0x00;
+		buf[i++] = 0x00;
 
 		if (data_size >= 9) {
-			buf[i++] = 0x20;		
+			buf[i++] = 0x20;
 		}
 		if (data_size >= 10) {
-			buf[i++] = 0x62;		
+			buf[i++] = 0x62;
 		}
 		if (data_size >= 11) {
-			buf[i++] = 0x00;		
+			buf[i++] = 0x00;
 		}
 		if (data_size >= 12) {
 			if (support_format) {
-				buf[i++] = 0xC0;	
+				buf[i++] = 0xC0;
 			} else {
 				buf[i++] = 0x00;
 			}
 		}
 	} else {
 		if (data_size >= 5) {
-			buf[i++] = 0x20;		
+			buf[i++] = 0x20;
 		}
 		if (data_size >= 6) {
-			buf[i++] = 0x62;		
+			buf[i++] = 0x62;
 		}
 		if (data_size >= 7) {
-			buf[i++] = 0x00;		
+			buf[i++] = 0x00;
 		}
 		if (data_size >= 8) {
 			if (support_format) {
-				buf[i++] = 0xC0;	
+				buf[i++] = 0xC0;
 			} else {
 				buf[i++] = 0x00;
 			}
@@ -579,7 +579,7 @@ static int mode_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int pro_formatter_flag;
 	unsigned char pageCode, *buf;
 	u8 card = get_lun_card(chip, lun);
-	
+
 #ifndef SUPPORT_MAGIC_GATE
 	if (!check_card_ready(chip, lun)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_NOT_PRESENT);
@@ -615,8 +615,8 @@ static int mode_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	pageCode = srb->cmnd[2] & 0x3f;
 
-	if ((pageCode == 0x3F) || (pageCode == 0x1C) || 
-		(pageCode == 0x00) || 
+	if ((pageCode == 0x3F) || (pageCode == 0x1C) ||
+		(pageCode == 0x00) ||
 		(pro_formatter_flag && (pageCode == 0x20))) {
 		if (srb->cmnd[0] == MODE_SENSE) {
 			if ((pageCode == 0x3F) || (pageCode == 0x20)) {
@@ -657,14 +657,14 @@ static int mode_sense(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		scsi_set_resid(srb, scsi_bufflen(srb));
 		status = TRANSPORT_FAILED;
 	}
-	
+
 	if (status == TRANSPORT_GOOD) {
 		unsigned int len = min(scsi_bufflen(srb), dataSize);
 		rtsx_stor_set_xfer_buf(buf, len, srb);
 		scsi_set_resid(srb, scsi_bufflen(srb) - len);
 	}
 	kfree(buf);
-	
+
 	return status;
 }
 
@@ -685,25 +685,25 @@ static int read_write(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	if (!check_card_ready(chip, lun) || (get_card_size(chip, lun) == 0)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_NOT_PRESENT);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (!(CHK_BIT(chip->lun_mc, lun))) {
 		SET_BIT(chip->lun_mc, lun);
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_CHANGE);
 		return TRANSPORT_FAILED;
 	}
-		
+
 #ifdef SUPPORT_SD_LOCK
 	if (sd_card->sd_erase_status) {
 		RTSX_DEBUGP(("SD card being erased!\n"));
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_READ_FORBIDDEN);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (get_lun_card(chip, lun) == SD_CARD) {
 		if (sd_card->sd_lock_status & SD_LOCKED) {
 			RTSX_DEBUGP(("SD card locked!\n"));
@@ -712,18 +712,18 @@ static int read_write(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 	}
 #endif
-	
+
 	if ((srb->cmnd[0] == READ_10) || (srb->cmnd[0] == WRITE_10)) {
-		start_sec = ((u32)srb->cmnd[2] << 24) | ((u32)srb->cmnd[3] << 16) | 
+		start_sec = ((u32)srb->cmnd[2] << 24) | ((u32)srb->cmnd[3] << 16) |
 			((u32)srb->cmnd[4] << 8) | ((u32)srb->cmnd[5]);
 		sec_cnt = ((u16)(srb->cmnd[7]) << 8) | srb->cmnd[8];
 	} else if ((srb->cmnd[0] == READ_6) || (srb->cmnd[0] == WRITE_6)) {
-		start_sec = ((u32)(srb->cmnd[1] & 0x1F) << 16) | 
+		start_sec = ((u32)(srb->cmnd[1] & 0x1F) << 16) |
 			((u32)srb->cmnd[2] << 8) | ((u32)srb->cmnd[3]);
 		sec_cnt = srb->cmnd[4];
-	} else if ((srb->cmnd[0] == VENDOR_CMND) && (srb->cmnd[1] == SCSI_APP_CMD) && 
+	} else if ((srb->cmnd[0] == VENDOR_CMND) && (srb->cmnd[1] == SCSI_APP_CMD) &&
 			((srb->cmnd[2] == PP_READ10) || (srb->cmnd[2] == PP_WRITE10))) {
-		start_sec = ((u32)srb->cmnd[4] << 24) | ((u32)srb->cmnd[5] << 16) | 
+		start_sec = ((u32)srb->cmnd[4] << 24) | ((u32)srb->cmnd[5] << 16) |
 			((u32)srb->cmnd[6] << 8) | ((u32)srb->cmnd[7]);
 		sec_cnt = ((u16)(srb->cmnd[9]) << 8) | srb->cmnd[10];
 	} else {
@@ -731,7 +731,7 @@ static int read_write(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
-	if ((start_sec > get_card_size(chip, lun)) || 
+	if ((start_sec > get_card_size(chip, lun)) ||
 			((start_sec + sec_cnt) > get_card_size(chip, lun))) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_LBA_OVER_RANGE);
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -751,7 +751,7 @@ static int read_write(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (srb->sc_data_direction == DMA_TO_DEVICE) {
 		if (check_card_wp(chip, lun)) {
 			RTSX_DEBUGP(("Write protected card!\n"));
@@ -783,7 +783,7 @@ static int read_write(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	scsi_set_resid(srb, 0);
 
 Exit:
-	
+
 	return retval;
 }
 
@@ -806,7 +806,7 @@ static int read_format_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 
 	buf_len = (scsi_bufflen(srb) > 12) ? 0x14 : 12;
-	
+
 	buf = kmalloc(buf_len, GFP_KERNEL);
 	if (buf == NULL) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
@@ -815,9 +815,9 @@ static int read_format_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	buf[i++] = 0;
 	buf[i++] = 0;
 	buf[i++] = 0;
-	
-	if ((buf_len > 12) && chip->mspro_formatter_enable && 
-			(chip->lun2card[lun] & MS_CARD) && 
+
+	if ((buf_len > 12) && chip->mspro_formatter_enable &&
+			(chip->lun2card[lun] & MS_CARD) &&
 			(!card || (card == MS_CARD))) {
 		buf[i++] = 0x10;
 		desc_cnt = 2;
@@ -825,7 +825,7 @@ static int read_format_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		buf[i++] = 0x08;
 		desc_cnt = 1;
 	}
-	
+
 	while (desc_cnt) {
 		if (check_card_ready(chip, lun)) {
 			card_size = get_card_size(chip, lun);
@@ -833,36 +833,36 @@ static int read_format_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			buf[i++] = (unsigned char)(card_size >> 16);
 			buf[i++] = (unsigned char)(card_size >> 8);
 			buf[i++] = (unsigned char)card_size;
-			
+
 			if (desc_cnt == 2) {
-				buf[i++] = 2;  
+				buf[i++] = 2;
 			} else {
-				buf[i++] = 0;  
+				buf[i++] = 0;
 			}
 		} else {
 			buf[i++] = 0xFF;
 			buf[i++] = 0xFF;
 			buf[i++] = 0xFF;
 			buf[i++] = 0xFF;
-			
+
 			if (desc_cnt == 2) {
-				buf[i++] = 3;  
+				buf[i++] = 3;
 			} else {
-				buf[i++] = 0;  
+				buf[i++] = 0;
 			}
 		}
-			
+
 		buf[i++] = 0x00;
 		buf[i++] = 0x02;
 		buf[i++] = 0x00;
-		
+
 		desc_cnt --;
 	}
-	
+
 	buf_len = min(scsi_bufflen(srb), buf_len);
 	rtsx_stor_set_xfer_buf(buf, buf_len, srb);
 	kfree(buf);
-	
+
 	scsi_set_resid(srb, scsi_bufflen(srb) - buf_len);
 
 	return TRANSPORT_GOOD;
@@ -889,7 +889,7 @@ static int read_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (buf == NULL) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
 	}
-	
+
 	card_size = get_card_size(chip, lun);
 	buf[0] = (unsigned char)((card_size - 1) >> 24);
 	buf[1] = (unsigned char)((card_size - 1) >> 16);
@@ -900,10 +900,10 @@ static int read_capacity(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	buf[5] = 0x00;
 	buf[6] = 0x02;
 	buf[7] = 0x00;
-		
+
 	rtsx_stor_set_xfer_buf(buf, scsi_bufflen(srb), srb);
 	kfree(buf);
-	
+
 	scsi_set_resid(srb, 0);
 
 	return TRANSPORT_GOOD;
@@ -1065,7 +1065,7 @@ static int trace_msg_cmd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	clear = srb->cmnd[2];
-		
+
 	buf = (unsigned char *)vmalloc(scsi_bufflen(srb));
 	if (buf == NULL) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
@@ -1090,7 +1090,7 @@ static int trace_msg_cmd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		if (idx < 0) {
 			idx += TRACE_ITEM_CNT;
 		}
-				
+
 		*(ptr++) = (u8)(chip->trace_msg[idx].line >> 8);
 		*(ptr++) = (u8)(chip->trace_msg[idx].line);
 		for (j = 0; j < MSG_FUNC_LEN; j++) {
@@ -1137,7 +1137,7 @@ static int read_host_reg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	val = rtsx_readl(chip, addr);
 	RTSX_DEBUGP(("Host register (0x%x): 0x%x\n", addr, val));
-	
+
 	buf[0] = (u8)(val >> 24);
 	buf[1] = (u8)(val >> 16);
 	buf[2] = (u8)(val >> 8);
@@ -1165,7 +1165,7 @@ static int write_host_reg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
 
 	addr = srb->cmnd[4];
-	
+
 	len = min(scsi_bufflen(srb), (unsigned int)4);
 	rtsx_stor_get_xfer_buf(buf, len, srb);
 	scsi_set_resid(srb, scsi_bufflen(srb) - len);
@@ -1180,9 +1180,9 @@ static int write_host_reg(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 static int set_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 {
 	unsigned lun = SCSI_LUN(srb);
-	
-	if (srb->cmnd[3] == 1) {   
-		struct sd_info *sd_card = &(chip->sd_card);		
+
+	if (srb->cmnd[3] == 1) {
+		struct sd_info *sd_card = &(chip->sd_card);
 		struct ms_info *ms_card = &(chip->ms_card);
 
 		switch (srb->cmnd[4]) {
@@ -1197,15 +1197,15 @@ static int set_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			default:
 				set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 				TRACE_RET(chip, TRANSPORT_FAILED);
-		}		
+		}
 	} else if (srb->cmnd[3] == 2) {
 		if (srb->cmnd[4]) {
 			chip->blink_led = 1;
 		} else {
 			int retval;
-			
+
 			chip->blink_led = 0;
-			
+
 			rtsx_enter_work_state(chip);
 
 			if (chip->ss_en && (rtsx_get_stat(chip) == RTSX_STAT_SS)) {
@@ -1213,13 +1213,13 @@ static int set_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 				wait_timeout(100);
 			}
 			rtsx_set_stat(chip, RTSX_STAT_RUN);
-			
+
 			retval = rtsx_force_power_on(chip, SSC_PDCTL);
 			if (retval != STATUS_SUCCESS) {
 				set_sense_type(chip, SCSI_LUN(srb), SENSE_TYPE_MEDIA_WRITE_ERR);
 				TRACE_RET(chip, TRANSPORT_FAILED);
 			}
-			
+
 			turn_off_led(chip);
 		}
 	} else {
@@ -1233,9 +1233,9 @@ static int set_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 static int get_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 {
 	unsigned int lun = SCSI_LUN(srb);
-	
-	if (srb->cmnd[3] == 1) {   
-		struct sd_info *sd_card = &(chip->sd_card);		
+
+	if (srb->cmnd[3] == 1) {
+		struct sd_info *sd_card = &(chip->sd_card);
 		struct ms_info *ms_card = &(chip->ms_card);
 		u8 tmp;
 
@@ -1256,7 +1256,7 @@ static int get_variable(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_stor_set_xfer_buf(&tmp, 1, srb);
 	} else if (srb->cmnd[3] == 2) {
 		u8 tmp = chip->blink_led;
-		
+
 		rtsx_stor_set_xfer_buf(&tmp, 1, srb);
 	} else {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
@@ -1289,7 +1289,7 @@ static int dma_access_ring_buffer(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		RTSX_DEBUGP(("Write to device\n"));
 	}
 
-	retval = rtsx_transfer_data(chip, 0, scsi_sglist(srb), len, 
+	retval = rtsx_transfer_data(chip, 0, scsi_sglist(srb), len,
 			scsi_sg_count(srb), srb->sc_data_direction, 1000);
 	if (retval < 0) {
 		if (srb->sc_data_direction == DMA_FROM_DEVICE) {
@@ -1297,11 +1297,11 @@ static int dma_access_ring_buffer(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		} else {
 			set_sense_type(chip, lun, SENSE_TYPE_MEDIA_WRITE_ERR);
 		}
-		TRACE_RET(chip, TRANSPORT_FAILED);		
+		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 	scsi_set_resid(srb, 0);
 
-	return TRANSPORT_GOOD;	
+	return TRANSPORT_GOOD;
 }
 
 static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -1326,7 +1326,7 @@ static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	} else {
 		status[2] = 0x00;
 	}
-	
+
 	status[3] = 20;
 	status[4] = 10;
 	status[5] = 5;
@@ -1342,7 +1342,7 @@ static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	status[8] = 0;
 	oc_now_mask = SD_OC_NOW;
 	oc_ever_mask = SD_OC_EVER;
-	
+
 	if (chip->ocp_stat & oc_now_mask) {
 		status[8] |= 0x02;
 	}
@@ -1355,14 +1355,14 @@ static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		if (CHK_SD(sd_card)) {
 			if (CHK_SD_HCXC(sd_card)) {
 				if (sd_card->capacity > 0x4000000) {
-					status[0x0E] = 0x02;  
+					status[0x0E] = 0x02;
 				} else {
-					status[0x0E] = 0x01;  
+					status[0x0E] = 0x01;
 				}
 			} else {
-				status[0x0E] = 0x00;  
+				status[0x0E] = 0x00;
 			}
-			
+
 			if (CHK_SD_SDR104(sd_card)) {
 				status[0x0F] = 0x03;
 			} else if (CHK_SD_DDR50(sd_card)) {
@@ -1372,33 +1372,33 @@ static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			} else if (CHK_SD_HS(sd_card)) {
 				status[0x0F] = 0x01;
 			} else {
-				status[0x0F] = 0x00;  
+				status[0x0F] = 0x00;
 			}
 		} else {
 			if (CHK_MMC_SECTOR_MODE(sd_card)) {
-				status[0x0E] = 0x01;  
+				status[0x0E] = 0x01;
 			} else {
-				status[0x0E] = 0x00;  
+				status[0x0E] = 0x00;
 			}
-			
+
 			if (CHK_MMC_DDR52(sd_card)) {
-				status[0x0F] = 0x03;  
+				status[0x0F] = 0x03;
 			} else if (CHK_MMC_52M(sd_card)) {
-				status[0x0F] = 0x02;  
+				status[0x0F] = 0x02;
 			} else if (CHK_MMC_26M(sd_card)) {
-				status[0x0F] = 0x01;  
+				status[0x0F] = 0x01;
 			} else {
-				status[0x0F] = 0x00;  
+				status[0x0F] = 0x00;
 			}
 		}
 	} else if (card == MS_CARD) {
 		if (CHK_MSPRO(ms_card)) {
 			if (CHK_MSXC(ms_card)) {
-				status[0x0E] = 0x01;  
+				status[0x0E] = 0x01;
 			} else {
 				status[0x0E] = 0x00;
 			}
-			
+
 			if (CHK_HG8BIT(ms_card)) {
 				status[0x0F] = 0x01;
 			} else {
@@ -1411,26 +1411,26 @@ static int get_dev_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (card == SD_CARD) {
 		status[0x17] = 0x80;
 		if (sd_card->sd_erase_status) {
-			status[0x17] |= 0x01;	
+			status[0x17] |= 0x01;
 		}
 		if (sd_card->sd_lock_status & SD_LOCKED) {
-			status[0x17] |= 0x02;	
-			status[0x07] |= 0x40;	
+			status[0x17] |= 0x02;
+			status[0x07] |= 0x40;
 		}
 		if (sd_card->sd_lock_status & SD_PWD_EXIST) {
-			status[0x17] |= 0x04;	
+			status[0x17] |= 0x04;
 		}
 	} else {
 		status[0x17] = 0x00;
 	}
-	
+
 	RTSX_DEBUGP(("status[0x17] = 0x%x\n", status[0x17]));
 #endif
 
 	status[0x18] = 0x8A;
 
 	status[0x1A] = 0x28;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	status[0x1F] = 0x01;
 #endif
@@ -1466,7 +1466,7 @@ static int get_card_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			status[6] = sd_card->func_group3_mask;
 			status[7] = sd_card->func_group4_mask;
 
-			
+
 			if (CHK_SD_XC(sd_card))
 				status[16] = PP_SD_XC;
 			else if (CHK_SD_HC(sd_card))
@@ -1494,7 +1494,7 @@ static int get_card_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 				status[23] = current_limit[sd_card->current_limit];
 			else
 				status[23] = 0;
-			
+
 		} else {
 			if (CHK_MMC_SECTOR_MODE(sd_card))
 				status[0] = PP_MMC_HC;
@@ -1572,7 +1572,7 @@ static int rw_mem_cmd_buf(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	default:
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
-		TRACE_RET(chip, TRANSPORT_FAILED);    	       
+		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
 	if (retval != STATUS_SUCCESS) {
@@ -1618,17 +1618,17 @@ static int read_phy_register(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	addr = ((u16)srb->cmnd[4] << 8) | srb->cmnd[5];
 	len = ((u16)srb->cmnd[6] << 8) | srb->cmnd[7];
-	
+
 	if (len % 2) {
 		len -= len % 2;
 	}
-	
+
 	if (len) {
 		buf = (u8 *)vmalloc(len);
 		if (!buf) {
 			TRACE_RET(chip, TRANSPORT_ERROR);
 		}
-		
+
 		retval = rtsx_force_power_on(chip, SSC_PDCTL);
 		if (retval != STATUS_SUCCESS) {
 			vfree(buf);
@@ -1643,7 +1643,7 @@ static int read_phy_register(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 				set_sense_type(chip, SCSI_LUN(srb), SENSE_TYPE_MEDIA_UNRECOVER_READ_ERR);
 				TRACE_RET(chip, TRANSPORT_FAILED);
 			}
-			
+
 			buf[2*i] = (u8)(val >> 8);
 			buf[2*i+1] = (u8)val;
 		}
@@ -1675,14 +1675,14 @@ static int write_phy_register(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	addr = ((u16)srb->cmnd[4] << 8) | srb->cmnd[5];
 	len = ((u16)srb->cmnd[6] << 8) | srb->cmnd[7];
-	
+
 	if (len % 2) {
 		len -= len % 2;
 	}
 
 	if (len) {
 		len = (unsigned short)min(scsi_bufflen(srb), (unsigned int)len);
-		
+
 		buf = (u8 *)vmalloc(len);
 		if (buf == NULL) {
 			TRACE_RET(chip, TRANSPORT_ERROR);
@@ -1720,7 +1720,7 @@ static int read_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	u8 func, cfg_mode;
 	u16 addr, len;
 	u8 *buf;
-	
+
 	rtsx_enter_work_state(chip);
 
 	if (chip->ss_en && (rtsx_get_stat(chip) == RTSX_STAT_SS)) {
@@ -1728,7 +1728,7 @@ static int read_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	/* bit [2-1]: func number
 	 * bit [3]: 1 -> cfg mode, 0 -> back door mode
 	 * bit [7-4]: RFU
@@ -1741,19 +1741,19 @@ static int read_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 	addr = ((u16)(srb->cmnd[4]) << 8) | srb->cmnd[5];
 	len = ((u16)(srb->cmnd[6]) << 8) | srb->cmnd[7];
-	
+
 	RTSX_DEBUGP(("%s: func = %d, addr = 0x%x, len = %d\n", __FUNCTION__, func, addr, len));
-	
+
 	if (func > 0) {
 		set_sense_type(chip, SCSI_LUN(srb), SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	buf = (u8 *)vmalloc(len);
 	if (!buf) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
 	}
-	
+
 	if (cfg_mode) {
 		int i;
 		for (i = 0; i < len; i++) {
@@ -1772,13 +1772,13 @@ static int read_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 	}
-	
+
 	len = (u16)min(scsi_bufflen(srb), (unsigned int)len);
 	rtsx_stor_set_xfer_buf(buf, len, srb);
 	scsi_set_resid(srb, scsi_bufflen(srb) - len);
 
 	vfree(buf);
-	
+
 	return TRANSPORT_GOOD;
 }
 
@@ -1788,7 +1788,7 @@ static int write_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	u8 func, cfg_mode;
 	u16 addr, len;
 	u8 *buf;
-	
+
 	rtsx_enter_work_state(chip);
 
 	if (chip->ss_en && (rtsx_get_stat(chip) == RTSX_STAT_SS)) {
@@ -1796,7 +1796,7 @@ static int write_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	/* bit [2-1]: func number
 	 * bit [3]: 1 -> cfg mode, 0 -> back door mode
 	 * bit [7-4]: RFU
@@ -1809,14 +1809,14 @@ static int write_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 	addr = ((u16)(srb->cmnd[4]) << 8) | srb->cmnd[5];
 	len = ((u16)(srb->cmnd[6]) << 8) | srb->cmnd[7];
-	
+
 	RTSX_DEBUGP(("%s: func = %d, addr = 0x%x\n", __FUNCTION__, func, addr));
-	
+
 	if (func > 0) {
 		set_sense_type(chip, SCSI_LUN(srb), SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	len = (unsigned short)min(scsi_bufflen(srb), (unsigned int)len);
 	buf = (u8 *)vmalloc(len);
 	if (!buf) {
@@ -1825,7 +1825,7 @@ static int write_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	rtsx_stor_get_xfer_buf(buf, len, srb);
 	scsi_set_resid(srb, scsi_bufflen(srb) - len);
-	
+
 	if (cfg_mode) {
 		int i;
 		for (i = 0; i < len; i++) {
@@ -1844,9 +1844,9 @@ static int write_cfg_byte(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 	}
-	
+
 	vfree(buf);
-	
+
 	return TRANSPORT_GOOD;
 }
 
@@ -1871,7 +1871,7 @@ static int app_cmd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		case GET_VAR:
 			result = get_variable(srb, chip);
 			break;
-		
+
 		case SET_VAR:
 			result = set_variable(srb, chip);
 			break;
@@ -1880,19 +1880,19 @@ static int app_cmd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		case DMA_WRITE:
 			result = dma_access_ring_buffer(srb, chip);
 			break;
-			
+
 		case READ_PHY:
 			result = read_phy_register(srb, chip);
 			break;
-			
+
 		case WRITE_PHY:
 			result = write_phy_register(srb, chip);
 			break;
-			
+
 		case READ_CFG:
 			result = read_cfg_byte(srb, chip);
 			break;
-			
+
 		case WRITE_CFG:
 			result = write_cfg_byte(srb, chip);
 			break;
@@ -1927,7 +1927,7 @@ static int read_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	u8 rtsx_status[16];
 	int buf_len;
 	unsigned int lun = SCSI_LUN(srb);
-	
+
 	rtsx_status[0] = (u8)(chip->vendor_id >> 8);
 	rtsx_status[1] = (u8)(chip->vendor_id);
 
@@ -1938,14 +1938,14 @@ static int read_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	if (chip->card_exist) {
 		if (chip->card_exist & SD_CARD) {
-			rtsx_status[5] = 2;		
+			rtsx_status[5] = 2;
 		} else if (chip->card_exist & MS_CARD) {
-			rtsx_status[5] = 3;		
+			rtsx_status[5] = 3;
 		} else {
-			rtsx_status[5] = 7;		
+			rtsx_status[5] = 7;
 		}
 	} else {
-		rtsx_status[5] = 7;			
+		rtsx_status[5] = 7;
 	}
 
 	rtsx_status[6] = 1;
@@ -1978,35 +1978,35 @@ static int read_status(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 	if (get_lun_card(chip, lun) == SD_CARD) {
 		struct sd_info *sd_card = &(chip->sd_card);
-		
+
 		rtsx_status[13] = 0x20;
 		if (CHK_SD(sd_card)) {
 			if (CHK_SD_HCXC(sd_card)) {
-				rtsx_status[13] |= 0x04;	
-			} 
+				rtsx_status[13] |= 0x04;
+			}
 			if (CHK_SD_HS(sd_card)) {
-				rtsx_status[13] |= 0x02;	
+				rtsx_status[13] |= 0x02;
 			}
 		} else {
-			rtsx_status[13] |= 0x08;		
+			rtsx_status[13] |= 0x08;
 			if (CHK_MMC_52M(sd_card)) {
-				rtsx_status[13] |= 0x02;	
+				rtsx_status[13] |= 0x02;
 			}
 			if (CHK_MMC_SECTOR_MODE(sd_card)) {
-				rtsx_status[13] |= 0x04;	
+				rtsx_status[13] |= 0x04;
 			}
 		}
 	} else if (get_lun_card(chip, lun) == MS_CARD) {
 		struct ms_info *ms_card = &(chip->ms_card);
 
 		if (CHK_MSPRO(ms_card)) {
-			rtsx_status[13] = 0x38;			
+			rtsx_status[13] = 0x38;
 			if (CHK_HG8BIT(ms_card)) {
-				rtsx_status[13] |= 0x04;	
-			} 
+				rtsx_status[13] |= 0x04;
+			}
 #ifdef SUPPORT_MSXC
 			if (CHK_MSXC(ms_card)) {
-				rtsx_status[13] |= 0x01;	
+				rtsx_status[13] |= 0x01;
 			}
 #endif
 		} else {
@@ -2070,7 +2070,7 @@ static int vendor_cmnd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		case TOGGLE_GPIO:
 			result = toggle_gpio_cmd(srb, chip);
 			break;
-			
+
 		case GET_SD_CSD:
 			result = get_sd_csd(srb, chip);
 			break;
@@ -2108,7 +2108,7 @@ static int ms_format_cmnd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
-	if ((srb->cmnd[3] != 0x4D) || (srb->cmnd[4] != 0x47) || (srb->cmnd[5] != 0x66) || 
+	if ((srb->cmnd[3] != 0x4D) || (srb->cmnd[4] != 0x47) || (srb->cmnd[5] != 0x66) ||
 			(srb->cmnd[6] != 0x6D) || (srb->cmnd[7] != 0x74)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -2167,7 +2167,7 @@ int get_ms_information(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	u8 *buf;
 	unsigned int buf_len;
 	int i;
-	
+
 	if (!check_card_ready(chip, lun)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_NOT_PRESENT);
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -2176,36 +2176,36 @@ int get_ms_information(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_LUN_NOT_SUPPORT);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
-	if ((srb->cmnd[2] != 0xB0) || (srb->cmnd[4] != 0x4D) || 
-		(srb->cmnd[5] != 0x53) || (srb->cmnd[6] != 0x49) || 
+
+	if ((srb->cmnd[2] != 0xB0) || (srb->cmnd[4] != 0x4D) ||
+		(srb->cmnd[5] != 0x53) || (srb->cmnd[6] != 0x49) ||
 		(srb->cmnd[7] != 0x44)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	dev_info_id = srb->cmnd[3];
-	if ((CHK_MSXC(ms_card) && (dev_info_id == 0x10)) || 
-			(!CHK_MSXC(ms_card) && (dev_info_id == 0x13)) || 
+	if ((CHK_MSXC(ms_card) && (dev_info_id == 0x10)) ||
+			(!CHK_MSXC(ms_card) && (dev_info_id == 0x13)) ||
 			!CHK_MSPRO(ms_card)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (dev_info_id == 0x15) {
 		buf_len = data_len = 0x3A;
 	} else {
 		buf_len = data_len = 0x6A;
 	}
-	
+
 	buf = (u8 *)kmalloc(buf_len, GFP_KERNEL);
 	if (!buf) {
 		TRACE_RET(chip, TRANSPORT_ERROR);
 	}
-	
+
 	i = 0;
-	buf[i++] = 0x00;		
-	buf[i++] = data_len; 		
+	buf[i++] = 0x00;
+	buf[i++] = data_len;
 	if (CHK_MSXC(ms_card)) {
 		buf[i++] = 0x03;
 	} else {
@@ -2216,30 +2216,30 @@ int get_ms_information(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	buf[i++] = 0x00;
 	buf[i++] = 0x00;
 	buf[i++] = 0x01;
-	
+
 	buf[i++] = dev_info_id;
 	if (dev_info_id == 0x15) {
 		data_len = 0x31;
 	} else {
 		data_len = 0x61;
 	}
-	buf[i++] = 0x00;		
-	buf[i++] = data_len; 		
+	buf[i++] = 0x00;
+	buf[i++] = data_len;
 	buf[i++] = 0x80;
 	if ((dev_info_id == 0x10) || (dev_info_id == 0x13)) {
 		memcpy(buf+i, ms_card->raw_sys_info, 96);
 	} else {
 		memcpy(buf+i, ms_card->raw_model_name, 48);
 	}
-	
+
 	rtsx_stor_set_xfer_buf(buf, buf_len, srb);
-	
+
 	if (dev_info_id == 0x15) {
 		scsi_set_resid(srb, scsi_bufflen(srb)-0x3C);
 	} else {
 		scsi_set_resid(srb, scsi_bufflen(srb)-0x6C);
 	}
-	
+
 	kfree(buf);
 	return STATUS_SUCCESS;
 }
@@ -2274,7 +2274,7 @@ static int sd_extention_cmnd(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	sd_cleanup_work(chip);
 
 	if (!check_card_ready(chip, lun)) {
@@ -2329,7 +2329,7 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	u8 key_format;
 
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
-	
+
 	rtsx_enter_work_state(chip);
 
 	if (chip->ss_en && (rtsx_get_stat(chip) == RTSX_STAT_SS)) {
@@ -2337,7 +2337,7 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	ms_cleanup_work(chip);
 
 	if (!check_card_ready(chip, lun)) {
@@ -2348,25 +2348,25 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_LUN_NOT_SUPPORT);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (srb->cmnd[7] != KC_MG_R_PRO) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (!CHK_MSPRO(ms_card)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	key_format = srb->cmnd[10] & 0x3F;
 	RTSX_DEBUGP(("key_format = 0x%x\n", key_format));
-	
+
 	switch (key_format) {
 	case KF_GET_LOC_EKB:
 		if ((scsi_bufflen(srb) == 0x41C) &&
 			(srb->cmnd[8] == 0x04) &&
-			(srb->cmnd[9] == 0x1C)) 
+			(srb->cmnd[9] == 0x1C))
 		{
 			retval = mg_get_local_EKB(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2377,11 +2377,11 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	case KF_RSP_CHG:
 		if ((scsi_bufflen(srb) == 0x24) &&
 			(srb->cmnd[8] == 0x00) &&
-			(srb->cmnd[9] == 0x24)) 
+			(srb->cmnd[9] == 0x24))
 		{
 			retval = mg_get_rsp_chg(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2392,16 +2392,16 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	case KF_GET_ICV:
 		ms_card->mg_entry_num = srb->cmnd[5];
 		if ((scsi_bufflen(srb) == 0x404) &&
 			(srb->cmnd[8] == 0x04) &&
-			(srb->cmnd[9] == 0x04) && 
-			(srb->cmnd[2] == 0x00) && 
-			(srb->cmnd[3] == 0x00) && 
-			(srb->cmnd[4] == 0x00) && 
-			(srb->cmnd[5] < 32)) 
+			(srb->cmnd[9] == 0x04) &&
+			(srb->cmnd[2] == 0x00) &&
+			(srb->cmnd[3] == 0x00) &&
+			(srb->cmnd[4] == 0x00) &&
+			(srb->cmnd[5] < 32))
 		{
 			retval = mg_get_ICV(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2412,12 +2412,12 @@ int mg_report_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	default:
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	scsi_set_resid(srb, 0);
 	return TRANSPORT_GOOD;
 }
@@ -2428,7 +2428,7 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	unsigned int lun = SCSI_LUN(srb);
 	int retval;
 	u8 key_format;
-	
+
 	RTSX_DEBUGP(("--%s--\n", __FUNCTION__));
 
 	rtsx_enter_work_state(chip);
@@ -2438,7 +2438,7 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		wait_timeout(100);
 	}
 	rtsx_set_stat(chip, RTSX_STAT_RUN);
-	
+
 	ms_cleanup_work(chip);
 
 	if (!check_card_ready(chip, lun)) {
@@ -2453,25 +2453,25 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_LUN_NOT_SUPPORT);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (srb->cmnd[7] != KC_MG_R_PRO) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	if (!CHK_MSPRO(ms_card)) {
 		set_sense_type(chip, lun, SENSE_TYPE_MG_INCOMPATIBLE_MEDIUM);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	key_format = srb->cmnd[10] & 0x3F;
 	RTSX_DEBUGP(("key_format = 0x%x\n", key_format));
-	
+
 	switch (key_format) {
 	case KF_SET_LEAF_ID:
 		if ((scsi_bufflen(srb) == 0x0C) &&
 			(srb->cmnd[8] == 0x00) &&
-			(srb->cmnd[9] == 0x0C)) 
+			(srb->cmnd[9] == 0x0C))
 		{
 			retval = mg_set_leaf_id(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2482,11 +2482,11 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	case KF_CHG_HOST:
 		if ((scsi_bufflen(srb) == 0x0C) &&
 			(srb->cmnd[8] == 0x00) &&
-			(srb->cmnd[9] == 0x0C)) 
+			(srb->cmnd[9] == 0x0C))
 		{
 			retval = mg_chg(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2497,11 +2497,11 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	case KF_RSP_HOST:
 		if ((scsi_bufflen(srb) == 0x0C) &&
 			(srb->cmnd[8] == 0x00) &&
-			(srb->cmnd[9] == 0x0C)) 
+			(srb->cmnd[9] == 0x0C))
 		{
 			retval = mg_rsp(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2512,16 +2512,16 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	case KF_SET_ICV:
 		ms_card->mg_entry_num = srb->cmnd[5];
 		if ((scsi_bufflen(srb) == 0x404) &&
 			(srb->cmnd[8] == 0x04) &&
-			(srb->cmnd[9] == 0x04) && 
-			(srb->cmnd[2] == 0x00) && 
-			(srb->cmnd[3] == 0x00) && 
-			(srb->cmnd[4] == 0x00) && 
-			(srb->cmnd[5] < 32)) 
+			(srb->cmnd[9] == 0x04) &&
+			(srb->cmnd[2] == 0x00) &&
+			(srb->cmnd[3] == 0x00) &&
+			(srb->cmnd[4] == 0x00) &&
+			(srb->cmnd[5] < 32))
 		{
 			retval = mg_set_ICV(srb, chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2532,12 +2532,12 @@ int mg_send_key(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 		break;
-		
+
 	default:
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	scsi_set_resid(srb, 0);
 	return TRANSPORT_GOOD;
 }
@@ -2554,19 +2554,19 @@ int rtsx_scsi_handler(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 #ifdef SUPPORT_SD_LOCK
 	if (sd_card->sd_erase_status) {
-		if (!((srb->cmnd[0] == VENDOR_CMND) && (srb->cmnd[1] == SCSI_APP_CMD) && 
-				(srb->cmnd[2] == GET_DEV_STATUS)) && 
+		if (!((srb->cmnd[0] == VENDOR_CMND) && (srb->cmnd[1] == SCSI_APP_CMD) &&
+				(srb->cmnd[2] == GET_DEV_STATUS)) &&
 				(srb->cmnd[0] != REQUEST_SENSE)) {
 			set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04, 0, 0);
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
 	}
 #endif
-	
-	if ((get_lun_card(chip, lun) == MS_CARD) && 
+
+	if ((get_lun_card(chip, lun) == MS_CARD) &&
 			(ms_card->format_status == FORMAT_IN_PROGRESS)) {
 		if ((srb->cmnd[0] != REQUEST_SENSE) && (srb->cmnd[0] != INQUIRY)) {
-			set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04, 
+			set_sense_data(chip, lun, CUR_ERR, 0x02, 0, 0x04, 0x04,
 					0, (u16)(ms_card->progress));
 			TRACE_RET(chip, TRANSPORT_FAILED);
 		}
@@ -2636,7 +2636,7 @@ int rtsx_scsi_handler(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		case CMD_MSPRO_MG_RKEY:
 			result = mg_report_key(srb, chip);
 			break;
-			
+
 		case CMD_MSPRO_MG_SKEY:
 			result = mg_send_key(srb, chip);
 			break;
@@ -2647,7 +2647,7 @@ int rtsx_scsi_handler(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		case VERIFY:
 			result = TRANSPORT_GOOD;
 			break;
-			
+
 		default:
 			set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 			result = TRANSPORT_FAILED;

--- a/rtsx_scsi.h
+++ b/rtsx_scsi.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -77,18 +77,18 @@
 #define SD_HW_RST		0xD6
 
 #ifdef SUPPORT_MAGIC_GATE
-#define CMD_MSPRO_MG_RKEY	0xA4   
-#define CMD_MSPRO_MG_SKEY	0xA3   
+#define CMD_MSPRO_MG_RKEY	0xA4
+#define CMD_MSPRO_MG_SKEY	0xA3
 
-#define KC_MG_R_PRO		0xBE   
+#define KC_MG_R_PRO		0xBE
 
-#define KF_SET_LEAF_ID		0x31   
-#define KF_GET_LOC_EKB		0x32   
-#define KF_CHG_HOST		0x33   
-#define KF_RSP_CHG		0x34   
-#define KF_RSP_HOST		0x35   
-#define KF_GET_ICV		0x36   
-#define KF_SET_ICV		0x37   
+#define KF_SET_LEAF_ID		0x31
+#define KF_GET_LOC_EKB		0x32
+#define KF_CHG_HOST		0x33
+#define KF_RSP_CHG		0x34
+#define KF_RSP_HOST		0x35
+#define KF_GET_ICV		0x36
+#define KF_SET_ICV		0x37
 #endif
 
 #define	SENSE_TYPE_NO_SENSE				0
@@ -109,7 +109,7 @@
 #define SENSE_TYPE_MG_WRITE_ERR				0x0e
 #endif
 #ifdef SUPPORT_SD_LOCK
-#define SENSE_TYPE_MEDIA_READ_FORBIDDEN			0x10  
+#define SENSE_TYPE_MEDIA_READ_FORBIDDEN			0x10
 #endif
 
 #define	PIO_MODE_0			0x01
@@ -145,7 +145,7 @@
 #endif
 
 
-#define PP_AUTO_DELINK_EN_DEF		0x10  
+#define PP_AUTO_DELINK_EN_DEF		0x10
 
 
 #define PP_VBUS_TOO_LOW			0x02
@@ -157,14 +157,14 @@
 
 #define PP_FLASH_CODE			0x40
 #define PP_CODE_MODE_FUNC		0x40
-#define PP_FLASH_OP_VER2		0x02  
+#define PP_FLASH_OP_VER2		0x02
 #define	PP_USB_SPEED_FUNCTION_SUPPORT	0x08
 
 
 
-#define PP_SD_LOCK_FUNC			0x01  
-#define PP_SD_LOCK_SUPPORT		0x80  
-#define PP_SD_ERASING			0x01  
+#define PP_SD_LOCK_FUNC			0x01
+#define PP_SD_LOCK_SUPPORT		0x80
+#define PP_SD_ERASING			0x01
 #define PP_SD_LOCKED			0x02
 #define PP_SD_PWD_EXIST			0x04
 
@@ -187,9 +187,9 @@
 
 void scsi_show_command(struct scsi_cmnd *srb);
 void set_sense_type(struct rtsx_chip *chip, unsigned int lun, int sense_type);
-void set_sense_data(struct rtsx_chip *chip, unsigned int lun, u8 err_code, u8 sense_key, 
+void set_sense_data(struct rtsx_chip *chip, unsigned int lun, u8 err_code, u8 sense_key,
 		u32 info, u8 asc, u8 ascq, u8 sns_key_info0, u16 sns_key_info1);
 int rtsx_scsi_handler(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 
-#endif   
+#endif
 

--- a/rtsx_sys.h
+++ b/rtsx_sys.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -54,5 +54,5 @@ static inline void notify_refresh_driver(struct rtsx_chip *chip)
 
 #define RTSX_MSG_IN_INT(x)
 
-#endif  
+#endif
 

--- a/rtsx_transport.c
+++ b/rtsx_transport.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -89,12 +89,12 @@ unsigned int rtsx_stor_access_xfer_buf(unsigned char *buffer,
 
 			if (sglen > buflen - cnt) {
 
-				
+
 				sglen = buflen - cnt;
 				*offset += sglen;
 			} else {
 
-				
+
 				*offset = 0;
 				++*index;
 				++sg;
@@ -114,7 +114,7 @@ unsigned int rtsx_stor_access_xfer_buf(unsigned char *buffer,
 					memcpy(buffer + cnt, ptr + poff, plen);
 				kunmap(page);
 
-				
+
 				poff = 0;
 				++page;
 				cnt += plen;
@@ -123,7 +123,7 @@ unsigned int rtsx_stor_access_xfer_buf(unsigned char *buffer,
 		}
 	}
 
-	
+
 	return cnt;
 }
 
@@ -165,7 +165,7 @@ void rtsx_invoke_transport(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	int result;
 
 	result = rtsx_scsi_handler(srb, chip);
-	
+
 	/* if the command gets aborted by the higher layers, we need to
 	 * short-circuit all other processing
 	 */
@@ -175,7 +175,7 @@ void rtsx_invoke_transport(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		goto Handle_Errors;
 	}
 
-	
+
 	if (result == TRANSPORT_ERROR) {
 		RTSX_DEBUGP(("-- transport indicates error, resetting\n"));
 		srb->result = DID_ERROR << 16;
@@ -185,14 +185,14 @@ void rtsx_invoke_transport(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	srb->result = SAM_STAT_GOOD;
 
 	/*
-	 * If we have a failure, we're going to do a REQUEST_SENSE 
+	 * If we have a failure, we're going to do a REQUEST_SENSE
 	 * automatically.  Note that we differentiate between a command
 	 * "failure" and an "error" in the transport mechanism.
 	 */
 	if (result == TRANSPORT_FAILED) {
-		
+
 		srb->result = SAM_STAT_CHECK_CONDITION;
-		memcpy(srb->sense_buffer, (unsigned char *)&(chip->sense_buffer[SCSI_LUN(srb)]), 
+		memcpy(srb->sense_buffer, (unsigned char *)&(chip->sense_buffer[SCSI_LUN(srb)]),
 				sizeof(struct sense_data_t));
 	}
 
@@ -202,7 +202,7 @@ void rtsx_invoke_transport(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	 * by issuing a port reset.  If that fails, try a class-specific
 	 * device reset. */
 Handle_Errors:
-	return;		
+	return;
 }
 
 /**
@@ -215,12 +215,12 @@ Handle_Errors:
  *
  * Add a command to command buffer.
  *
- * Usually, this function is called after rtsx_init_cmd, which 
- * intializes the command index to zero. After all commands are added, 
+ * Usually, this function is called after rtsx_init_cmd, which
+ * intializes the command index to zero. After all commands are added,
  * rtsx_send_cmd or rtsx_send_cmd_no_wait should be called to send those
  * commands to card reader chip.
  */
-void rtsx_add_cmd(struct rtsx_chip *chip, 
+void rtsx_add_cmd(struct rtsx_chip *chip,
 		u8 cmd_type, u16 reg_addr, u8 mask, u8 data)
 {
 	u32 *cb = (u32 *)(chip->host_cmds_ptr);
@@ -242,7 +242,7 @@ void rtsx_add_cmd(struct rtsx_chip *chip,
  * rtsx_send_cmd_no_wait - send commands to chip.
  * @chip: Realtek's card reader chip
  *
- * Trigger card reader chip to fetch commands from command buffer. 
+ * Trigger card reader chip to fetch commands from command buffer.
  * This funtion returns immediately.
  */
 void rtsx_send_cmd_no_wait(struct rtsx_chip *chip)
@@ -262,7 +262,7 @@ void rtsx_send_cmd_no_wait(struct rtsx_chip *chip)
  * @card: this command is relevant to card or not
  * @timeout: time out in millisecond
  *
- * Trigger card reader chip to fetch commands from command buffer. 
+ * Trigger card reader chip to fetch commands from command buffer.
  * This funtion will wait for transfer-finished interrupt.
  *
  * Returns zero if successful, or a negative error code on failure.
@@ -274,7 +274,7 @@ int rtsx_send_cmd(struct rtsx_chip *chip, u8 card, int timeout)
 	u32 val = 1 << 31;
 	long timeleft;
 	int err = 0;
-	
+
 	if (card == SD_CARD) {
 		rtsx->check_card_cd = SD_EXIST;
 	} else if (card == MS_CARD) {
@@ -285,12 +285,12 @@ int rtsx_send_cmd(struct rtsx_chip *chip, u8 card, int timeout)
 
 	spin_lock_irq(&rtsx->reg_lock);
 
-	
+
 	rtsx->done = &trans_done;
 	rtsx->trans_result = TRANS_NOT_READY;
 	init_completion(&trans_done);
 	rtsx->trans_state = STATE_TRANS_CMD;
-	
+
 	rtsx_writel(chip, RTSX_HCBAR, chip->host_cmds_addr);
 
 	val |= (u32)(chip->ci * 4) & 0x00FFFFFF;
@@ -313,7 +313,7 @@ int rtsx_send_cmd(struct rtsx_chip *chip, u8 card, int timeout)
 		err = 0;
 	}
 	spin_unlock_irq(&rtsx->reg_lock);
-	
+
 
 finish_send_cmd:
 	rtsx->done = NULL;
@@ -335,8 +335,8 @@ finish_send_cmd:
  *
  * Add a sg entry to sg table.
  *
- * Note: The length field is 20-bit long. So if the buffer length is 
- * longer than 0x80000, this function will divide the buffer into 
+ * Note: The length field is 20-bit long. So if the buffer length is
+ * longer than 0x80000, this function will divide the buffer into
  * several small buffers to ensure the length field won't overflow.
  */
 static inline void rtsx_add_sg_tbl(struct rtsx_chip *chip, u32 addr, u32 len, u8 option)
@@ -377,15 +377,15 @@ static inline void rtsx_add_sg_tbl(struct rtsx_chip *chip, u32 addr, u32 len, u8
  * @dma_dir: transfer direction (DMA_FROM_DEVICE or DMA_TO_DEVICE)
  * @timeout: time out in millisecond
  *
- * Transfer partial data in scatter-gather mode. In this mode, 
- * ADMA option will be turned on. 
+ * Transfer partial data in scatter-gather mode. In this mode,
+ * ADMA option will be turned on.
  *
- * This function is usually called in MS card flow. In MS 
- * read/write function, one transfer stage will be divided to several stages. 
- * The *index and *offset variables are used to record the postion in 
+ * This function is usually called in MS card flow. In MS
+ * read/write function, one transfer stage will be divided to several stages.
+ * The *index and *offset variables are used to record the postion in
  * scatter-gather list that the next transfer will pick up.
  */
-static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, struct scatterlist *sg, 
+static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, struct scatterlist *sg,
 		int num_sg, unsigned int *index, unsigned int *offset, int size,
 	       	enum dma_data_direction dma_dir, int timeout)
 {
@@ -409,7 +409,7 @@ static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, st
 	} else {
 		return -ENXIO;
 	}
-	
+
 	if (card == SD_CARD) {
 		rtsx->check_card_cd = SD_EXIST;
 	} else if (card == MS_CARD) {
@@ -424,9 +424,9 @@ static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, st
 
 	rtsx->trans_state = STATE_TRANS_SG;
 	rtsx->trans_result = TRANS_NOT_READY;
-	
+
 	spin_unlock_irq(&rtsx->reg_lock);
-	
+
 	sg_cnt = dma_map_sg(&(rtsx->pci->dev), sg, num_sg, dma_dir);
 
 	resid = size;
@@ -439,7 +439,7 @@ static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, st
 		dma_addr_t addr;
 		unsigned int len;
 		u8 option;
-		
+
 		addr = sg_dma_address(sg_ptr);
 		len = sg_dma_len(sg_ptr);
 
@@ -469,7 +469,7 @@ static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, st
 		if (!resid) {
 			break;
 		}
-		
+
 		sg_ptr = sg_next(sg_ptr);
 	}
 
@@ -479,12 +479,12 @@ static int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, st
 	val |= ADMA_MODE;
 
 	spin_lock_irq(&rtsx->reg_lock);
-	
+
 	init_completion(&trans_done);
-	
+
 	rtsx_writel(chip, RTSX_HDBAR, chip->host_sg_tbl_addr);
 	rtsx_writel(chip, RTSX_HDBCTLR, val);
-	
+
 	spin_unlock_irq(&rtsx->reg_lock);
 
 	timeleft = wait_for_completion_interruptible_timeout(&trans_done, timeout * HZ / 1000);
@@ -552,9 +552,9 @@ out:
  * @dma_dir: transfer direction (DMA_FROM_DEVICE or DMA_TO_DEVICE)
  * @timeout: time out in millisecond
  *
- * Transfer data in scatter-gather mode. In this mode, ADMA option will be turned on. 
+ * Transfer data in scatter-gather mode. In this mode, ADMA option will be turned on.
  */
-static int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct scatterlist *sg, 
+static int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct scatterlist *sg,
 		int num_sg, enum dma_data_direction dma_dir, int timeout)
 {
 	struct rtsx_dev *rtsx = chip->rtsx;
@@ -584,16 +584,16 @@ static int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct sca
 	} else {
 		rtsx->check_card_cd = 0;
 	}
-	
+
 	spin_lock_irq(&rtsx->reg_lock);
 
 	rtsx->done = &trans_done;
 
 	rtsx->trans_state = STATE_TRANS_SG;
 	rtsx->trans_result = TRANS_NOT_READY;
-	
+
 	spin_unlock_irq(&rtsx->reg_lock);
-	
+
 	buf_cnt = dma_map_sg(&(rtsx->pci->dev), sg, num_sg, dma_dir);
 
 	sg_ptr = sg;
@@ -623,7 +623,7 @@ static int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct sca
 			}
 
 			rtsx_add_sg_tbl(chip, (u32)addr, (u32)len, option);
-			
+
 			sg_ptr = sg_next(sg_ptr);
 		}
 
@@ -633,12 +633,12 @@ static int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct sca
 		val |= ADMA_MODE;
 
 		spin_lock_irq(&rtsx->reg_lock);
-		
+
 		init_completion(&trans_done);
-		
+
 		rtsx_writel(chip, RTSX_HDBAR, chip->host_sg_tbl_addr);
 		rtsx_writel(chip, RTSX_HDBCTLR, val);
-		
+
 		spin_unlock_irq(&rtsx->reg_lock);
 
 		timeleft = wait_for_completion_interruptible_timeout(&trans_done, timeout * HZ / 1000);
@@ -696,7 +696,7 @@ out:
 		CATCH_TRIGGER1(chip);
 	}
 
-	return err;	
+	return err;
 }
 
 /**
@@ -708,9 +708,9 @@ out:
  * @dma_dir: transfer direction (DMA_FROM_DEVICE or DMA_TO_DEVICE)
  * @timeout: time out in millisecond
  *
- * Transfer data in linear buffer. 
+ * Transfer data in linear buffer.
  */
-static int rtsx_transfer_buf(struct rtsx_chip *chip, u8 card, void *buf, size_t len, 
+static int rtsx_transfer_buf(struct rtsx_chip *chip, u8 card, void *buf, size_t len,
 		enum dma_data_direction dma_dir, int timeout)
 {
 	struct rtsx_dev *rtsx = chip->rtsx;
@@ -737,7 +737,7 @@ static int rtsx_transfer_buf(struct rtsx_chip *chip, u8 card, void *buf, size_t 
 	if (!addr) {
 		return -ENOMEM;
 	}
-	
+
 	if (card == SD_CARD) {
 		rtsx->check_card_cd = SD_EXIST;
 	} else if (card == MS_CARD) {
@@ -754,13 +754,13 @@ static int rtsx_transfer_buf(struct rtsx_chip *chip, u8 card, void *buf, size_t 
 	rtsx->done = &trans_done;
 
 	init_completion(&trans_done);
-	
+
 	rtsx->trans_state = STATE_TRANS_BUF;
 	rtsx->trans_result = TRANS_NOT_READY;
-	
+
 	rtsx_writel(chip, RTSX_HDBAR, addr);
 	rtsx_writel(chip, RTSX_HDBCTLR, val);
-	
+
 	spin_unlock_irq(&rtsx->reg_lock);
 
 	timeleft = wait_for_completion_interruptible_timeout(&trans_done, timeout * HZ / 1000);
@@ -795,24 +795,24 @@ out:
 	return err;
 }
 
-int rtsx_transfer_data_partial(struct rtsx_chip *chip, u8 card, void *buf, size_t len, 
-		int use_sg, unsigned int *index, unsigned int *offset, 
+int rtsx_transfer_data_partial(struct rtsx_chip *chip, u8 card, void *buf, size_t len,
+		int use_sg, unsigned int *index, unsigned int *offset,
 		enum dma_data_direction dma_dir, int timeout)
 {
 	int err = 0;
-	
-	
+
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_ABORT)) {
 		return -EIO;
 	}
-	
+
 	if (use_sg) {
-		err = rtsx_transfer_sglist_adma_partial(chip, card, (struct scatterlist *)buf, 
+		err = rtsx_transfer_sglist_adma_partial(chip, card, (struct scatterlist *)buf,
 				use_sg, index, offset, (int)len, dma_dir, timeout);
 	} else {
 		err = rtsx_transfer_buf(chip, card, buf, len, dma_dir, timeout);
 	}
-	
+
 	if (err < 0) {
 		if (RTSX_TST_DELINK(chip)) {
 			RTSX_CLR_DELINK(chip);
@@ -824,20 +824,20 @@ int rtsx_transfer_data_partial(struct rtsx_chip *chip, u8 card, void *buf, size_
 	return err;
 }
 
-int rtsx_transfer_data(struct rtsx_chip *chip, u8 card, void *buf, size_t len, 
+int rtsx_transfer_data(struct rtsx_chip *chip, u8 card, void *buf, size_t len,
 		int use_sg, enum dma_data_direction dma_dir, int timeout)
 {
 	int err = 0;
-	
+
 	RTSX_DEBUGP(("use_sg = %d\n", use_sg));
-	
-	
+
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_ABORT)) {
 		return -EIO;
 	}
 
 	if (use_sg) {
-		err = rtsx_transfer_sglist_adma(chip, card, (struct scatterlist *)buf, 
+		err = rtsx_transfer_sglist_adma(chip, card, (struct scatterlist *)buf,
 				use_sg, dma_dir, timeout);
 	} else {
 		err = rtsx_transfer_buf(chip, card, buf, len, dma_dir, timeout);

--- a/rtsx_transport.h
+++ b/rtsx_transport.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -41,7 +41,7 @@ void rtsx_invoke_transport(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 
 #define rtsx_init_cmd(chip)			((chip)->ci = 0)
 
-void rtsx_add_cmd(struct rtsx_chip *chip, 
+void rtsx_add_cmd(struct rtsx_chip *chip,
 		u8 cmd_type, u16 reg_addr, u8 mask, u8 data);
 void rtsx_send_cmd_no_wait(struct rtsx_chip *chip);
 int rtsx_send_cmd(struct rtsx_chip *chip, u8 card, int timeout);
@@ -55,12 +55,12 @@ extern inline u8 *rtsx_get_cmd_data(struct rtsx_chip *chip)
 #endif
 }
 
-int rtsx_transfer_data(struct rtsx_chip *chip, u8 card, void *buf, size_t len, 
+int rtsx_transfer_data(struct rtsx_chip *chip, u8 card, void *buf, size_t len,
 		int use_sg, enum dma_data_direction dma_dir, int timeout);
 
-int rtsx_transfer_data_partial(struct rtsx_chip *chip, u8 card, void *buf, size_t len, 
-		int use_sg, unsigned int *index, unsigned int *offset, 
+int rtsx_transfer_data_partial(struct rtsx_chip *chip, u8 card, void *buf, size_t len,
+		int use_sg, unsigned int *index, unsigned int *offset,
 		enum dma_data_direction dma_dir, int timeout);
 
-#endif   
+#endif
 

--- a/sd.c
+++ b/sd.c
@@ -1,6 +1,6 @@
 /* Driver for Realtek PCI-Express card reader
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -45,7 +45,7 @@ static inline void sd_clr_err_code(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 
-	sd_card->err_code = 0;	
+	sd_card->err_code = 0;
 }
 
 static inline int sd_check_err_code(struct rtsx_chip *chip, u8 err_code)
@@ -58,18 +58,18 @@ static inline int sd_check_err_code(struct rtsx_chip *chip, u8 err_code)
 static int sd_check_data0_status(struct rtsx_chip *chip)
 {
 	u8 stat;
-	
+
 	RTSX_READ_REG(chip, SD_BUS_STAT, &stat);
 
 	if (!(stat & SD_DAT0_STATUS)) {
 		sd_set_err_code(chip, SD_BUSY);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
-static int sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx, 
+static int sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx,
 		u32 arg, u8 rsp_type, u8 *rsp, int rsp_len)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
@@ -99,11 +99,11 @@ RTY_SEND_CMD:
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD4, 0xFF, (u8)arg);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, rsp_type);
-	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE, 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE,
 			0x01, PINGPONG_BUFFER);
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER,
 			0xFF, SD_TM_CMD_RSP | SD_TRANSFER_START);
-	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, 
+	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER,
 		     SD_TRANSFER_END | SD_STAT_IDLE, SD_TRANSFER_END | SD_STAT_IDLE);
 
 	if (rsp_type == SD_RSP_TYPE_R2) {
@@ -116,7 +116,7 @@ RTY_SEND_CMD:
 			rtsx_add_cmd(chip, READ_REG_CMD, reg_addr, 0, 0);
 		}
 		stat_idx = 5;
-	} 
+	}
 
 	rtsx_add_cmd(chip, READ_REG_CMD, SD_STAT1, 0, 0);
 
@@ -125,20 +125,20 @@ RTY_SEND_CMD:
 		u8 val;
 
 		rtsx_read_register(chip, SD_STAT1, &val);
-		RTSX_DEBUGP(("SD_STAT1: 0x%x\n", val));	
-		
+		RTSX_DEBUGP(("SD_STAT1: 0x%x\n", val));
+
 		rtsx_read_register(chip, SD_STAT2, &val);
 		RTSX_DEBUGP(("SD_STAT2: 0x%x\n", val));
-		
+
 		if (val & SD_RSP_80CLK_TIMEOUT) {
 			rtsx_clear_sd_error(chip);
 			sd_set_err_code(chip, SD_RSP_TIMEOUT);
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		rtsx_read_register(chip, SD_BUS_STAT, &val);
 		RTSX_DEBUGP(("SD_BUS_STAT: 0x%x\n", val));
-		
+
 		if (retval == -ETIMEDOUT) {
 			if (rsp_type & SD_WAIT_BUSY_END) {
 				retval = sd_check_data0_status(chip);
@@ -162,7 +162,7 @@ RTY_SEND_CMD:
 		return STATUS_SUCCESS;
 	}
 
-	ptr = rtsx_get_cmd_data(chip) + 1;  
+	ptr = rtsx_get_cmd_data(chip) + 1;
 
 	if ((ptr[0] & 0xC0) != 0) {
 		sd_set_err_code(chip, SD_STS_ERR);
@@ -194,9 +194,9 @@ RTY_SEND_CMD:
 				}
 			}
 #ifdef SUPPORT_SD_LOCK
-			if (ptr[1] & 0x7D) 
+			if (ptr[1] & 0x7D)
 #else
-			if (ptr[1] & 0x7F) 
+			if (ptr[1] & 0x7F)
 #endif
 			{
 				RTSX_DEBUGP(("ptr[1]: 0x%02x\n", ptr[1]));
@@ -208,9 +208,9 @@ RTY_SEND_CMD:
 			}
 			if (ptr[3] & 0x80) {
 				RTSX_DEBUGP(("ptr[3]: 0x%02x\n", ptr[3]));
-				TRACE_RET(chip, STATUS_FAIL);		
+				TRACE_RET(chip, STATUS_FAIL);
 			}
-			if (ptr[3] & 0x01) { 
+			if (ptr[3] & 0x01) {
 				sd_card->sd_data_buf_ready = 1;
 			} else {
 				sd_card->sd_data_buf_ready = 0;
@@ -231,11 +231,11 @@ static inline void sd_print_debug_reg(struct rtsx_chip *chip)
 	u8 val;
 
 	rtsx_read_register(chip, SD_STAT1, &val);
-	RTSX_DEBUGP(("SD_STAT1: 0x%x\n", val));	
-	
+	RTSX_DEBUGP(("SD_STAT1: 0x%x\n", val));
+
 	rtsx_read_register(chip, SD_STAT2, &val);
 	RTSX_DEBUGP(("SD_STAT2: 0x%x\n", val));
-	
+
 	rtsx_read_register(chip, SD_BUS_STAT, &val);
 	RTSX_DEBUGP(("SD_BUS_STAT: 0x%x\n", val));
 
@@ -257,27 +257,27 @@ static inline void sd_print_debug_reg(struct rtsx_chip *chip)
 	RTSX_DEBUGP(("SD_BLOCK_CNT_L: 0x%02x\n", val));
 	rtsx_read_register(chip, SD_BLOCK_CNT_H, &val);
 	RTSX_DEBUGP(("SD_BLOCK_CNT_H: 0x%02x\n", val));
-		
+
 #endif
 }
 
-static int sd_read_data(struct rtsx_chip *chip, u8 trans_mode, u8 *cmd, int cmd_len, 
+static int sd_read_data(struct rtsx_chip *chip, u8 trans_mode, u8 *cmd, int cmd_len,
 		u16 byte_cnt, u16 blk_cnt, u8 bus_width, u8 *buf, int buf_len, int timeout)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	int i;
-	
+
 	sd_clr_err_code(chip);
 
 	if (!buf) {
 		buf_len = 0;
 	}
-	
+
 	if (buf_len && (buf_len > PPBUF_LEN)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	rtsx_init_cmd(chip);
 
 	if (cmd_len) {
@@ -293,8 +293,8 @@ static int sd_read_data(struct rtsx_chip *chip, u8 trans_mode, u8 *cmd, int cmd_
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG1, 0x03, bus_width);
 
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, 
-			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF,
+			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 			SD_CHECK_CRC7 | SD_RSP_LEN_6);
 	if (trans_mode != SD_TM_AUTO_TUNING) {
 		rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE, 0x01, PINGPONG_BUFFER);
@@ -305,7 +305,7 @@ static int sd_read_data(struct rtsx_chip *chip, u8 trans_mode, u8 *cmd, int cmd_
 	retval = rtsx_send_cmd(chip, SD_CARD, timeout);
 	if (retval < 0) {
 		sd_print_debug_reg(chip);
-		
+
 		if (retval == -ETIMEDOUT) {
 			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
@@ -319,12 +319,12 @@ static int sd_read_data(struct rtsx_chip *chip, u8 trans_mode, u8 *cmd, int cmd_
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
-static int sd_write_data(struct rtsx_chip *chip, u8 trans_mode, 
-		u8 *cmd, int cmd_len, u16 byte_cnt, u16 blk_cnt, u8 bus_width, 
+static int sd_write_data(struct rtsx_chip *chip, u8 trans_mode,
+		u8 *cmd, int cmd_len, u16 byte_cnt, u16 blk_cnt, u8 bus_width,
 		u8 *buf, int buf_len, int timeout)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
@@ -336,11 +336,11 @@ static int sd_write_data(struct rtsx_chip *chip, u8 trans_mode,
 	if (!buf) {
 		buf_len = 0;
 	}
-	
+
 	if (buf_len > PPBUF_LEN) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (buf && buf_len) {
 		retval = rtsx_write_ppbuf(chip, buf, buf_len);
 		if (retval != STATUS_SUCCESS) {
@@ -349,7 +349,7 @@ static int sd_write_data(struct rtsx_chip *chip, u8 trans_mode,
 	}
 
 	rtsx_init_cmd(chip);
-	
+
 	if (cmd_len) {
 		RTSX_DEBUGP(("SD/MMC CMD %d\n", cmd[0] - 0x40));
 		for (i = 0; i < (cmd_len < 6 ? cmd_len : 6); i++) {
@@ -363,21 +363,21 @@ static int sd_write_data(struct rtsx_chip *chip, u8 trans_mode,
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG1, 0x03, bus_width);
 
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, 
-		SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF,
+		SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 		SD_CHECK_CRC7 | SD_RSP_LEN_6);
-		
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, trans_mode | SD_TRANSFER_START);
 	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
 
 	retval = rtsx_send_cmd(chip, SD_CARD, timeout);
 	if (retval < 0) {
 		sd_print_debug_reg(chip);
-		
+
 		if (retval == -ETIMEDOUT) {
 			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
-		
+
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
@@ -409,7 +409,7 @@ static int sd_check_csd(struct rtsx_chip *chip, char check_wp)
 	}
 
 	memcpy(sd_card->raw_csd, rsp + 1, 15);
-	
+
 	RTSX_READ_REG(chip, SD_CMD5, sd_card->raw_csd + 15);
 
 	RTSX_DEBUGP(("CSD Response:\n"));
@@ -419,32 +419,32 @@ static int sd_check_csd(struct rtsx_chip *chip, char check_wp)
 	RTSX_DEBUGP(("csd_ver = %d\n", csd_ver));
 
 	trans_speed = rsp[4];
-	if ((trans_speed & 0x07) == 0x02) {	
-		if ((trans_speed & 0xf8) >= 0x30) { 		
+	if ((trans_speed & 0x07) == 0x02) {
+		if ((trans_speed & 0xf8) >= 0x30) {
 			if (chip->asic_code) {
 				sd_card->sd_clock = 47;
 			} else {
 				sd_card->sd_clock = CLK_50;
 			}
-		} else if ((trans_speed & 0xf8) == 0x28) {	
+		} else if ((trans_speed & 0xf8) == 0x28) {
 			if (chip->asic_code) {
 				sd_card->sd_clock = 39;
 			} else {
 				sd_card->sd_clock = CLK_40;
 			}
-		} else if ((trans_speed & 0xf8) == 0x20) {	
+		} else if ((trans_speed & 0xf8) == 0x20) {
 			if (chip->asic_code) {
 				sd_card->sd_clock = 29;
 			} else {
 				sd_card->sd_clock = CLK_30;
 			}
-		} else if ((trans_speed & 0xf8) >= 0x10) {	
+		} else if ((trans_speed & 0xf8) >= 0x10) {
 			if (chip->asic_code) {
 				sd_card->sd_clock = 23;
 			} else {
 				sd_card->sd_clock = CLK_20;
 			}
-		} else if ((trans_speed & 0x08) >= 0x08) {	
+		} else if ((trans_speed & 0x08) >= 0x08) {
 			if (chip->asic_code) {
 				sd_card->sd_clock = 19;
 			} else {
@@ -472,7 +472,7 @@ static int sd_check_csd(struct rtsx_chip *chip, char check_wp)
 			sd_card->capacity = (((u32)(c_size + 1)) * (1 << (c_size_mult + 2))) << (blk_size - 9);
 		} else {
 			u32 total_sector = 0;
-			total_sector = (((u32)rsp[8] & 0x3f) << 16) | 
+			total_sector = (((u32)rsp[8] & 0x3f) << 16) |
 				((u32)rsp[9] << 8) | (u32)rsp[10];
 			sd_card->capacity = (total_sector + 1) << 10;
 		}
@@ -480,7 +480,7 @@ static int sd_check_csd(struct rtsx_chip *chip, char check_wp)
 
 	if (check_wp) {
 		if (rsp[15] & 0x30) {
-			chip->card_wp |= SD_CARD;			
+			chip->card_wp |= SD_CARD;
 		}
 		RTSX_DEBUGP(("CSD WP Status: 0x%x\n", rsp[15]));
 	}
@@ -491,31 +491,31 @@ static int sd_check_csd(struct rtsx_chip *chip, char check_wp)
 static int sd_set_sample_push_timing(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
-	
+
 	if (CHK_SD_SDR104(sd_card) || CHK_SD_SDR50(sd_card)) {
-		RTSX_WRITE_REG(chip, SD_CFG1, 0x0C | SD_ASYNC_FIFO_NOT_RST, 
+		RTSX_WRITE_REG(chip, SD_CFG1, 0x0C | SD_ASYNC_FIFO_NOT_RST,
 				SD_30_MODE | SD_ASYNC_FIFO_NOT_RST);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, CLK_LOW_FREQ);
-		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF, 
+		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF,
 				CRC_VAR_CLK0 | SD30_FIX_CLK | SAMPLE_VAR_CLK1);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, 0);
 	} else if (CHK_SD_DDR50(sd_card) || CHK_MMC_DDR52(sd_card)) {
-		RTSX_WRITE_REG(chip, SD_CFG1, 0x0C | SD_ASYNC_FIFO_NOT_RST, 
+		RTSX_WRITE_REG(chip, SD_CFG1, 0x0C | SD_ASYNC_FIFO_NOT_RST,
 				SD_DDR_MODE | SD_ASYNC_FIFO_NOT_RST);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, CLK_LOW_FREQ);
-		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF, 
+		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF,
 				CRC_VAR_CLK0 | SD30_FIX_CLK | SAMPLE_VAR_CLK1);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, 0);
-		RTSX_WRITE_REG(chip, SD_PUSH_POINT_CTL, DDR_VAR_TX_CMD_DAT, 
+		RTSX_WRITE_REG(chip, SD_PUSH_POINT_CTL, DDR_VAR_TX_CMD_DAT,
 				DDR_VAR_TX_CMD_DAT);
 		RTSX_WRITE_REG(chip, SD_SAMPLE_POINT_CTL, DDR_VAR_RX_DAT | DDR_VAR_RX_CMD,
 				DDR_VAR_RX_DAT | DDR_VAR_RX_CMD);
 	} else {
 		u8 val = 0;
-		
+
 		RTSX_WRITE_REG(chip, SD_CFG1, 0x0C, SD_20_MODE);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, CLK_LOW_FREQ);
-		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF, 
+		RTSX_WRITE_REG(chip, CARD_CLK_SOURCE, 0xFF,
 				CRC_FIX_CLK | SD30_VAR_CLK0 | SAMPLE_VAR_CLK1);
 		RTSX_WRITE_REG(chip, CLK_CTL, CLK_LOW_FREQ, 0);
 
@@ -527,7 +527,7 @@ static int sd_set_sample_push_timing(struct rtsx_chip *chip)
 			val = SD20_TX_NEG_EDGE;
 		}
 		RTSX_WRITE_REG(chip, SD_PUSH_POINT_CTL, SD20_TX_SEL_MASK, val);
-		
+
 		if ((chip->sd_ctl & SD_SAMPLE_POINT_CTL_MASK) == SD_SAMPLE_POINT_AUTO) {
 			if (chip->asic_code) {
 				if (CHK_SD_HS(sd_card) || CHK_MMC_52M(sd_card)) {
@@ -545,14 +545,14 @@ static int sd_set_sample_push_timing(struct rtsx_chip *chip)
 		}
 		RTSX_WRITE_REG(chip, SD_SAMPLE_POINT_CTL, SD20_RX_SEL_MASK, val);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
 static void sd_choose_proper_clock(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
-	
+
 	if (CHK_SD_SDR104(sd_card)) {
 		if (chip->asic_code) {
 			sd_card->sd_clock = chip->asic_sd_sdr104_clk;
@@ -595,7 +595,7 @@ static void sd_choose_proper_clock(struct rtsx_chip *chip)
 static int sd_set_clock_divider(struct rtsx_chip *chip, u8 clk_div)
 {
 	RTSX_WRITE_REG(chip, SD_CFG1, SD_CLK_DIVIDE_MASK, clk_div);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -610,7 +610,7 @@ static int sd_set_init_para(struct rtsx_chip *chip)
 	}
 
 	sd_choose_proper_clock(chip);
-	
+
 	retval = switch_clock(chip, sd_card->sd_clock);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -650,24 +650,24 @@ static int sd_update_lock_status(struct rtsx_chip *chip)
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	u8 rsp[5];
-	
+
 	retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, rsp, 5);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (rsp[1] & 0x02) {
 		sd_card->sd_lock_status |= SD_LOCKED;
 	} else {
 		sd_card->sd_lock_status &= ~SD_LOCKED;
 	}
-	
+
 	RTSX_DEBUGP(("sd_card->sd_lock_status = 0x%x\n", sd_card->sd_lock_status));
-	
+
 	if (rsp[1] & 0x01) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 #endif
@@ -677,14 +677,14 @@ static int sd_wait_state_data_ready(struct rtsx_chip *chip, u8 state, u8 data_re
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval, i;
 	u8 rsp[5];
-	
+
 	for (i = 0; i < polling_cnt; i++) {
-		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS,
 					     sd_card->sd_addr, SD_RSP_TYPE_R1, rsp, 5);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		if (((rsp[3] & 0x1E) == state) && ((rsp[3] & 0x01) == data_ready)) {
 			return STATUS_SUCCESS;
 		}
@@ -696,7 +696,7 @@ static int sd_wait_state_data_ready(struct rtsx_chip *chip, u8 state, u8 data_re
 static int sd_change_bank_voltage(struct rtsx_chip *chip, u8 voltage)
 {
 	int retval;
-	
+
 	if (voltage == SD_IO_3V3) {
 		if (chip->asic_code) {
 			retval = rtsx_write_phy_register(chip, 0x08, 0x4FC0 | chip->phy_voltage);
@@ -718,7 +718,7 @@ static int sd_change_bank_voltage(struct rtsx_chip *chip, u8 voltage)
 	} else {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -733,11 +733,11 @@ static int sd_voltage_switch(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	udelay(chip->sd_voltage_switch_delay);
 
 	RTSX_READ_REG(chip, SD_BUS_STAT, &stat);
-	if (stat & (SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS | 
+	if (stat & (SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS |
 				SD_DAT1_STATUS | SD_DAT0_STATUS)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -753,9 +753,9 @@ static int sd_voltage_switch(struct rtsx_chip *chip)
 	wait_timeout(10);
 
 	RTSX_READ_REG(chip, SD_BUS_STAT, &stat);
-	if ((stat & (SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS | 
-				SD_DAT1_STATUS | SD_DAT0_STATUS)) != 
-			(SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS | 
+	if ((stat & (SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS |
+				SD_DAT1_STATUS | SD_DAT0_STATUS)) !=
+			(SD_CMD_STATUS | SD_DAT3_STATUS | SD_DAT2_STATUS |
 				SD_DAT1_STATUS | SD_DAT0_STATUS)) {
 		RTSX_DEBUGP(("SD_BUS_STAT: 0x%x\n", stat));
 		rtsx_write_register(chip, SD_BUS_STAT, SD_CLK_TOGGLE_EN | SD_CLK_FORCE_STOP, 0);
@@ -789,7 +789,7 @@ static int sd_change_phase(struct rtsx_chip *chip, u8 sample_point, u8 tune_dir)
 	int retval;
 	int ddr_rx = 0;
 
-	RTSX_DEBUGP(("sd_change_phase (sample_point = %d, tune_dir = %d)\n", 
+	RTSX_DEBUGP(("sd_change_phase (sample_point = %d, tune_dir = %d)\n",
 				sample_point, tune_dir));
 
 	if (tune_dir == TUNE_RX) {
@@ -820,16 +820,16 @@ static int sd_change_phase(struct rtsx_chip *chip, u8 sample_point, u8 tune_dir)
 		if (ddr_rx) {
 			RTSX_WRITE_REG(chip, SD_VP_CTL, PHASE_CHANGE, PHASE_CHANGE);
 			udelay(50);
-			RTSX_WRITE_REG(chip, SD_VP_CTL, 0xFF, 
+			RTSX_WRITE_REG(chip, SD_VP_CTL, 0xFF,
 					PHASE_CHANGE | PHASE_NOT_RESET | sample_point);
 		} else {
 			RTSX_WRITE_REG(chip, CLK_CTL, CHANGE_CLK, CHANGE_CLK);
 			udelay(50);
-			RTSX_WRITE_REG(chip, SD_VP_CTL, 0xFF, 
+			RTSX_WRITE_REG(chip, SD_VP_CTL, 0xFF,
 					PHASE_NOT_RESET | sample_point);
 		}
 		udelay(100);
-		
+
 		rtsx_init_cmd(chip);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_DCMPS_CTL, DCMPS_CHANGE, DCMPS_CHANGE);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_DCMPS_CTL, DCMPS_CHANGE_DONE, DCMPS_CHANGE_DONE);
@@ -837,7 +837,7 @@ static int sd_change_phase(struct rtsx_chip *chip, u8 sample_point, u8 tune_dir)
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, Fail);
 		}
-		
+
 		val = *rtsx_get_cmd_data(chip);
 		if (val & DCMPS_ERROR) {
 			TRACE_GOTO(chip, Fail);
@@ -853,11 +853,11 @@ static int sd_change_phase(struct rtsx_chip *chip, u8 sample_point, u8 tune_dir)
 		}
 		udelay(50);
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG1, SD_ASYNC_FIFO_NOT_RST, 0);
 
 	return STATUS_SUCCESS;
-	
+
 Fail:
 #if DBG
 	rtsx_read_register(chip, SD_VP_CTL, &val);
@@ -865,7 +865,7 @@ Fail:
 	rtsx_read_register(chip, SD_DCMPS_CTL, &val);
 	RTSX_DEBUGP(("SD_DCMPS_CTL: 0x%x\n", val));
 #endif
-	
+
 	rtsx_write_register(chip, SD_DCMPS_CTL, DCMPS_CHANGE, 0);
 	rtsx_write_register(chip, SD_VP_CTL, PHASE_CHANGE, 0);
 	wait_timeout(10);
@@ -905,7 +905,7 @@ static int sd_check_spec(struct rtsx_chip *chip, u8 bus_width)
 	return STATUS_SUCCESS;
 }
 
-static int sd_query_switch_result(struct rtsx_chip *chip, u8 func_group, u8 func_to_switch, 
+static int sd_query_switch_result(struct rtsx_chip *chip, u8 func_group, u8 func_to_switch,
 		u8 *buf, int buf_len)
 {
 	u8 support_mask = 0, query_switch = 0, switch_busy = 0;
@@ -1003,30 +1003,30 @@ static int sd_query_switch_result(struct rtsx_chip *chip, u8 func_group, u8 func
 	}
 
 	if (func_group == SD_FUNC_GROUP_1) {
-		if (!(buf[support_offset] & support_mask) || 
+		if (!(buf[support_offset] & support_mask) ||
 				((buf[query_switch_offset] & 0x0F) != query_switch)) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
 
-	if ((buf[DATA_STRUCTURE_VER_OFFSET] == 0x01) && 
+	if ((buf[DATA_STRUCTURE_VER_OFFSET] == 0x01) &&
 		    ((buf[check_busy_offset] & switch_busy) == switch_busy)) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
-static int sd_check_switch_mode(struct rtsx_chip *chip, u8 mode, 
+static int sd_check_switch_mode(struct rtsx_chip *chip, u8 mode,
 		u8 func_group, u8 func_to_switch, u8 bus_width)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	u8 cmd[5], buf[64];
 
-	RTSX_DEBUGP(("sd_check_switch_mode (mode = %d, func_group = %d, func_to_switch = %d)\n", 
+	RTSX_DEBUGP(("sd_check_switch_mode (mode = %d, func_group = %d, func_to_switch = %d)\n",
 			mode, func_group, func_to_switch));
-	
+
 	cmd[0] = 0x40 | SWITCH;
 	cmd[1] = mode;
 
@@ -1054,7 +1054,7 @@ static int sd_check_switch_mode(struct rtsx_chip *chip, u8 mode,
 		rtsx_clear_sd_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_DUMP(buf, 64);
 
 	if (func_group == NO_ARGUMENT) {
@@ -1077,7 +1077,7 @@ static int sd_check_switch_mode(struct rtsx_chip *chip, u8 mode,
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		if ((cc > 400) || (func_to_switch > CURRENT_LIMIT_400)) {
 			RTSX_WRITE_REG(chip, OCPPARA2, SD_OCP_THD_MASK, chip->sd_800mA_ocp_thd);
 			RTSX_WRITE_REG(chip, CARD_PWR_CTL, PMOS_STRG_MASK, PMOS_STRG_800mA);
@@ -1098,11 +1098,11 @@ static u8 downgrade_switch_mode(u8 func_group, u8 func_to_switch)
 			func_to_switch --;
 		}
 	}
-	
+
 	return func_to_switch;
 }
 
-static int sd_check_switch(struct rtsx_chip *chip, 
+static int sd_check_switch(struct rtsx_chip *chip,
 		u8 func_group, u8 func_to_switch, u8 bus_width)
 {
 	int retval;
@@ -1115,12 +1115,12 @@ static int sd_check_switch(struct rtsx_chip *chip,
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 
-		retval = sd_check_switch_mode(chip, SD_CHECK_MODE, func_group, 
+		retval = sd_check_switch_mode(chip, SD_CHECK_MODE, func_group,
 				func_to_switch, bus_width);
 		if (retval == STATUS_SUCCESS) {
 			u8 stat;
 
-			retval = sd_check_switch_mode(chip, SD_SWITCH_MODE, 
+			retval = sd_check_switch_mode(chip, SD_SWITCH_MODE,
 					func_group, func_to_switch, bus_width);
 			if (retval == STATUS_SUCCESS) {
 				switch_good = 1;
@@ -1133,7 +1133,7 @@ static int sd_check_switch(struct rtsx_chip *chip,
 				TRACE_RET(chip, STATUS_FAIL);
 			}
 		}
-		
+
 		func_to_switch = downgrade_switch_mode(func_group, func_to_switch);
 
 		wait_timeout(20);
@@ -1143,7 +1143,7 @@ static int sd_check_switch(struct rtsx_chip *chip,
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
@@ -1152,8 +1152,8 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 	int retval;
 	int i;
 	u8 func_to_switch = 0;
-	
-	retval = sd_check_switch_mode(chip, SD_CHECK_MODE, 
+
+	retval = sd_check_switch_mode(chip, SD_CHECK_MODE,
 			NO_ARGUMENT, NO_ARGUMENT, bus_width);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1170,36 +1170,36 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 				func_to_switch = SDR104_SUPPORT;
 			}
 			break;
-			
+
 		case DDR50_SUPPORT:
 			if ((sd_card->func_group1_mask & DDR50_SUPPORT_MASK) && chip->ddr50_en) {
 				func_to_switch = DDR50_SUPPORT;
 			}
 			break;
-			
+
 		case SDR50_SUPPORT:
 			if ((sd_card->func_group1_mask & SDR50_SUPPORT_MASK) && chip->sdr50_en) {
 				func_to_switch = SDR50_SUPPORT;
 			}
 			break;
-			
+
 		case HS_SUPPORT:
 			if (sd_card->func_group1_mask & HS_SUPPORT_MASK) {
 				func_to_switch = HS_SUPPORT;
 			}
 			break;
-			
+
 		default:
 			continue;
 		}
-		
-		
+
+
 		if (func_to_switch) {
 			break;
 		}
 	}
 	RTSX_DEBUGP(("SD_FUNC_GROUP_1: func_to_switch = 0x%02x", func_to_switch));
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if((sd_card->sd_lock_status & SD_SDR_RST)
 			&& (DDR50_SUPPORT == func_to_switch)
@@ -1208,18 +1208,18 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 		RTSX_DEBUGP(("Using SDR50 instead of DDR50 for SD Lock\n"));
 	}
 #endif
-	
+
 	if (func_to_switch) {
 		retval = sd_check_switch(chip, SD_FUNC_GROUP_1, func_to_switch, bus_width);
 		if (retval != STATUS_SUCCESS) {
 			if (func_to_switch == SDR104_SUPPORT) {
 				sd_card->sd_switch_fail = SDR104_SUPPORT_MASK;
 			} else if (func_to_switch == DDR50_SUPPORT) {
-				sd_card->sd_switch_fail = 
+				sd_card->sd_switch_fail =
 					SDR104_SUPPORT_MASK | DDR50_SUPPORT_MASK;
 			} else if (func_to_switch == SDR50_SUPPORT) {
-				sd_card->sd_switch_fail = 
-					SDR104_SUPPORT_MASK | DDR50_SUPPORT_MASK | 
+				sd_card->sd_switch_fail =
+					SDR104_SUPPORT_MASK | DDR50_SUPPORT_MASK |
 					SDR50_SUPPORT_MASK;
 			}
 			TRACE_RET(chip, STATUS_FAIL);
@@ -1247,7 +1247,7 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 	if (!func_to_switch || (func_to_switch == HS_SUPPORT)) {
 		return STATUS_SUCCESS;
 	}
-	
+
 	func_to_switch = 0xFF;
 
 	for (i = 0; i < 4; i++) {
@@ -1257,30 +1257,30 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 				func_to_switch = CURRENT_LIMIT_800;
 			}
 			break;
-			
+
 		case CURRENT_LIMIT_600:
 			if (sd_card->func_group4_mask & CURRENT_LIMIT_600_MASK) {
 				func_to_switch = CURRENT_LIMIT_600;
 			}
 			break;
-			
+
 		case CURRENT_LIMIT_400:
 			if (sd_card->func_group4_mask & CURRENT_LIMIT_400_MASK) {
 				func_to_switch = CURRENT_LIMIT_400;
 			}
 			break;
-			
+
 		case CURRENT_LIMIT_200:
 			if (sd_card->func_group4_mask & CURRENT_LIMIT_200_MASK) {
 				func_to_switch = CURRENT_LIMIT_200;
 			}
 			break;
-			
+
 		default:
 			continue;
 		}
-		
-		
+
+
 		if (func_to_switch != 0xFF) {
 			break;
 		}
@@ -1302,7 +1302,7 @@ static int sd_switch_function(struct rtsx_chip *chip, u8 bus_width)
 		RTSX_DEBUGP(("sd_card->current_limit = 0x%x\n",	sd_card->current_limit));
 		RTSX_DEBUGP(("Switch current limit finished! (%d)\n", retval));
 	}
-	
+
 	if (CHK_SD_DDR50(sd_card)) {
 		RTSX_WRITE_REG(chip, SD_PUSH_POINT_CTL, 0x06, 0);
 	}
@@ -1315,7 +1315,7 @@ static int sd_wait_data_idle(struct rtsx_chip *chip)
 	int retval = STATUS_TIMEDOUT;
 	int i;
 	u8 val = 0;
-	
+
 	for (i = 0; i < 100; i++) {
 		RTSX_READ_REG(chip, SD_DATA_STATE, &val);
 		if (val & SD_DATA_IDLE) {
@@ -1325,7 +1325,7 @@ static int sd_wait_data_idle(struct rtsx_chip *chip)
 		udelay(100);
 	}
 	RTSX_DEBUGP(("SD_DATA_STATE: 0x%02x\n", val));
-	
+
 	return retval;
 }
 
@@ -1333,27 +1333,27 @@ static int sd_sdr_tuning_rx_cmd(struct rtsx_chip *chip, u8 sample_point)
 {
 	int retval;
 	u8 cmd[5];
-	
+
 	retval = sd_change_phase(chip, sample_point, TUNE_RX);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	cmd[0] = 0x40 | SEND_TUNING_PATTERN;
 	cmd[1] = 0;
 	cmd[2] = 0;
 	cmd[3] = 0;
 	cmd[4] = 0;
 
-	retval = sd_read_data(chip, SD_TM_AUTO_TUNING, 
+	retval = sd_read_data(chip, SD_TM_AUTO_TUNING,
 			cmd, 5, 0x40, 1, SD_BUS_WIDTH_4, NULL, 0, 100);
 	if (retval != STATUS_SUCCESS) {
 		(void)sd_wait_data_idle(chip);
-		
+
 		rtsx_clear_sd_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1362,14 +1362,14 @@ static int sd_ddr_tuning_rx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	u8 cmd[5];
-	
+
 	retval = sd_change_phase(chip, sample_point, TUNE_RX);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
 	RTSX_DEBUGP(("sd ddr tuning rx\n"));
-	
+
 	retval = sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -1381,15 +1381,15 @@ static int sd_ddr_tuning_rx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	cmd[3] = 0;
 	cmd[4] = 0;
 
-	retval = sd_read_data(chip, SD_TM_NORMAL_READ, 
+	retval = sd_read_data(chip, SD_TM_NORMAL_READ,
 			cmd, 5, 64, 1, SD_BUS_WIDTH_4, NULL, 0, 100);
 	if (retval != STATUS_SUCCESS) {
 		(void)sd_wait_data_idle(chip);
-		
+
 		rtsx_clear_sd_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1398,7 +1398,7 @@ static int mmc_ddr_tunning_rx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	u8 cmd[5], bus_width;
-	
+
 	if (CHK_MMC_8BIT(sd_card)) {
 		bus_width = SD_BUS_WIDTH_8;
 	} else if (CHK_MMC_4BIT(sd_card)) {
@@ -1420,11 +1420,11 @@ static int mmc_ddr_tunning_rx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	cmd[3] = 0;
 	cmd[4] = 0;
 
-	retval = sd_read_data(chip, SD_TM_NORMAL_READ, 
+	retval = sd_read_data(chip, SD_TM_NORMAL_READ,
 			cmd, 5, 0x200, 1, bus_width, NULL, 0, 100);
 	if (retval != STATUS_SUCCESS) {
 		(void)sd_wait_data_idle(chip);
-		
+
 		rtsx_clear_sd_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -1441,10 +1441,10 @@ static int sd_sdr_tuning_tx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, SD_RSP_80CLK_TIMEOUT_EN);
-	
-	retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+
+	retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 		SD_RSP_TYPE_R1, NULL, 0);
 	if (retval != STATUS_SUCCESS) {
 		if (sd_check_err_code(chip, SD_RSP_TIMEOUT)) {
@@ -1452,9 +1452,9 @@ static int sd_sdr_tuning_tx_cmd(struct rtsx_chip *chip, u8 sample_point)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, 0);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1468,7 +1468,7 @@ static int sd_ddr_tuning_tx_cmd(struct rtsx_chip *chip, u8 sample_point)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (CHK_SD(sd_card)) {
 		bus_width = SD_BUS_WIDTH_4;
 	} else {
@@ -1480,14 +1480,14 @@ static int sd_ddr_tuning_tx_cmd(struct rtsx_chip *chip, u8 sample_point)
 			bus_width = SD_BUS_WIDTH_1;
 		}
 	}
-	
+
 	retval = sd_wait_state_data_ready(chip, 0x08, 1, 1000);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, SD_RSP_80CLK_TIMEOUT_EN);
-	
+
 	cmd[0] = 0x40 | PROGRAM_CSD;
 	cmd[1] = 0;
 	cmd[2] = 0;
@@ -1501,11 +1501,11 @@ static int sd_ddr_tuning_tx_cmd(struct rtsx_chip *chip, u8 sample_point)
 		rtsx_write_register(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, 0);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, 0);
-	
+
 	sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1516,17 +1516,17 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 	int i, j, cont_path_cnt;
 	int new_block, max_len, final_path_idx;
 	u8 final_phase = 0xFF;
-	
+
 	if (phase_map == 0xFFFFFFFF) {
 		if (tune_dir == TUNE_RX) {
 			final_phase = (u8)chip->sd_default_rx_phase;
 		} else {
 			final_phase = (u8)chip->sd_default_tx_phase;
 		}
-		
+
 		goto Search_Finish;
 	}
-	
+
 	cont_path_cnt = 0;
 	new_block = 1;
 	j = 0;
@@ -1549,7 +1549,7 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 			}
 		}
 	}
-	
+
 	if (cont_path_cnt == 0) {
 		RTSX_DEBUGP(("No continuous phase path\n"));
 		goto Search_Finish;
@@ -1558,9 +1558,9 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 		path[idx].len = path[idx].end - path[idx].start + 1;
 		path[idx].mid = path[idx].start + path[idx].len / 2;
 	}
-	
+
 	if ((path[0].start == 0) && (path[cont_path_cnt - 1].end == MAX_PHASE)) {
-		path[0].start = path[cont_path_cnt - 1].start - MAX_PHASE - 1; 
+		path[0].start = path[cont_path_cnt - 1].start - MAX_PHASE - 1;
 		path[0].len += path[cont_path_cnt - 1].len;
 		path[0].mid = path[0].start + path[0].len / 2;
 		if (path[0].mid < 0) {
@@ -1568,7 +1568,7 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 		}
 		cont_path_cnt --;
 	}
-	
+
 	max_len = 0;
 	final_phase = 0;
 	final_path_idx = 0;
@@ -1578,21 +1578,21 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 			final_phase = (u8)path[i].mid;
 			final_path_idx = i;
 		}
-		
+
 		RTSX_DEBUGP(("path[%d].start = %d\n", i, path[i].start));
 		RTSX_DEBUGP(("path[%d].end = %d\n", i, path[i].end));
 		RTSX_DEBUGP(("path[%d].len = %d\n", i, path[i].len));
 		RTSX_DEBUGP(("path[%d].mid = %d\n", i, path[i].mid));
 		RTSX_DEBUGP(("\n"));
 	}
-	
+
 	if (tune_dir == TUNE_TX) {
 		if (CHK_SD_SDR104(sd_card)) {
 			if( max_len > 15 ) {
-				int temp_mid = (max_len - 16) / 2;	
-				int temp_final_phase =  
+				int temp_mid = (max_len - 16) / 2;
+				int temp_final_phase =
 					path[final_path_idx].end - (max_len - (6 + temp_mid));
-				
+
 				if (temp_final_phase < 0) {
 					final_phase = (u8)(temp_final_phase + MAX_PHASE + 1);
 				} else {
@@ -1601,10 +1601,10 @@ static u8 sd_search_final_phase(struct rtsx_chip *chip, u32 phase_map, u8 tune_d
 			}
 		} else if (CHK_SD_SDR50(sd_card)) {
 			if( max_len > 12 ) {
-				int temp_mid = (max_len - 13) / 2;	
-				int temp_final_phase = 
+				int temp_mid = (max_len - 13) / 2;
+				int temp_final_phase =
 					path[final_path_idx].end - (max_len - (3 + temp_mid));
-				
+
 				if (temp_final_phase < 0) {
 					final_phase = (u8)(temp_final_phase + MAX_PHASE + 1);
 				} else {
@@ -1641,7 +1641,7 @@ static int sd_tuning_rx(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	for (i = 0; i < RX_TUNING_CNT; i++) {
 		raw_phase_map[i] = 0;
 		for (j = MAX_PHASE; j >= 0; j--) {
@@ -1649,7 +1649,7 @@ static int sd_tuning_rx(struct rtsx_chip *chip)
 				sd_set_err_code(chip, SD_NO_CARD);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-			
+
 			retval = tuning_cmd(chip, (u8)j);
 			if (retval == STATUS_SUCCESS) {
 				raw_phase_map[i] |= 1 << j;
@@ -1659,24 +1659,24 @@ static int sd_tuning_rx(struct rtsx_chip *chip)
 		if (raw_phase_map[i] == 0)
 			break;
 	}
-	
+
 	phase_map = 0xFFFFFFFF;
 	for (i = 0; i < RX_TUNING_CNT; i++) {
 		RTSX_DEBUGP(("RX raw_phase_map[%d] = 0x%08x\n", i, raw_phase_map[i]));
 		phase_map &= raw_phase_map[i];
 	}
 	RTSX_DEBUGP(("RX phase_map = 0x%08x\n", phase_map));
-	
+
 	final_phase = sd_search_final_phase(chip, phase_map, TUNE_RX);
 	if (final_phase == 0xFF) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_change_phase(chip, final_phase, TUNE_RX);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1687,46 +1687,46 @@ static int sd_ddr_pre_tuning_tx(struct rtsx_chip *chip)
 	int i;
 	u32 phase_map;
 	u8 final_phase;
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, SD_RSP_80CLK_TIMEOUT_EN);
-	
+
 	phase_map = 0;
 	for (i = MAX_PHASE; i >= 0; i--) {
 		if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 			sd_set_err_code(chip, SD_NO_CARD);
-			rtsx_write_register(chip, SD_CFG3, 
+			rtsx_write_register(chip, SD_CFG3,
 						SD_RSP_80CLK_TIMEOUT_EN, 0);
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		retval = sd_change_phase(chip, (u8)i, TUNE_TX);
 		if (retval != STATUS_SUCCESS) {
 			continue;
 		}
-		
-		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+
+		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 				SD_RSP_TYPE_R1, NULL, 0);
 		if ((retval == STATUS_SUCCESS) || !sd_check_err_code(chip, SD_RSP_TIMEOUT)) {
 			phase_map |= 1 << i;
 		}
 	}
-	
+
 	RTSX_WRITE_REG(chip, SD_CFG3, SD_RSP_80CLK_TIMEOUT_EN, 0);
-	
+
 	RTSX_DEBUGP(("DDR TX pre tune phase_map = 0x%08x\n", phase_map));
-	
+
 	final_phase = sd_search_final_phase(chip, phase_map, TUNE_TX);
 	if (final_phase == 0xFF) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_change_phase(chip, final_phase, TUNE_TX);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_DEBUGP(("DDR TX pre tune phase: %d\n", (int)final_phase));
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1752,17 +1752,17 @@ static int sd_tuning_tx(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	for (i = 0; i < TX_TUNING_CNT; i++) {
 		raw_phase_map[i] = 0;
 		for (j = MAX_PHASE; j >= 0; j--) {
 			if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 				sd_set_err_code(chip, SD_NO_CARD);
-				rtsx_write_register(chip, SD_CFG3, 
+				rtsx_write_register(chip, SD_CFG3,
 						    SD_RSP_80CLK_TIMEOUT_EN, 0);
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-		
+
 			retval = tuning_cmd(chip, (u8)j);
 			if (retval == STATUS_SUCCESS) {
 				raw_phase_map[i] |= 1 << j;
@@ -1772,24 +1772,24 @@ static int sd_tuning_tx(struct rtsx_chip *chip)
 		if (raw_phase_map[i] == 0)
 			break;
 	}
-	
+
 	phase_map = 0xFFFFFFFF;
 	for (i = 0; i < TX_TUNING_CNT; i++) {
 		RTSX_DEBUGP(("TX raw_phase_map[%d] = 0x%08x\n", i, raw_phase_map[i]));
 		phase_map &= raw_phase_map[i];
 	}
 	RTSX_DEBUGP(("TX phase_map = 0x%08x\n", phase_map));
-	
+
 	final_phase = sd_search_final_phase(chip, phase_map, TUNE_TX);
 	if (final_phase == 0xFF) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_change_phase(chip, final_phase, TUNE_TX);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1801,19 +1801,19 @@ static int sd_sdr_tuning(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_tuning_rx(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
 static int sd_ddr_tuning(struct rtsx_chip *chip)
 {
 	int retval;
-	
+
 	if (!(chip->sd_ctl & SD_DDR_TX_PHASE_SET_BY_USER)) {
 		retval = sd_ddr_pre_tuning_tx(chip);
 		if (retval != STATUS_SUCCESS) {
@@ -1825,26 +1825,26 @@ static int sd_ddr_tuning(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	retval = sd_tuning_rx(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (!(chip->sd_ctl & SD_DDR_TX_PHASE_SET_BY_USER)) {
 		retval = sd_tuning_tx(chip);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
 static int mmc_ddr_tuning(struct rtsx_chip *chip)
 {
 	int retval;
-	
+
 	if (!(chip->sd_ctl & MMC_DDR_TX_PHASE_SET_BY_USER)) {
 		retval = sd_ddr_pre_tuning_tx(chip);
 		if (retval != STATUS_SUCCESS) {
@@ -1856,19 +1856,19 @@ static int mmc_ddr_tuning(struct rtsx_chip *chip)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	retval = sd_tuning_rx(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (!(chip->sd_ctl & MMC_DDR_TX_PHASE_SET_BY_USER)) {
 		retval = sd_tuning_tx(chip);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1877,12 +1877,12 @@ int sd_switch_clock(struct rtsx_chip *chip)
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
 	int re_tuning = 0;
-	
+
 	retval = select_card(chip, SD_CARD);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if ((CHK_SD30_SPEED(sd_card) || CHK_MMC_DDR52(sd_card))) {
 		if (sd_card->need_retune && (sd_card->sd_clock != chip->cur_clk)) {
 			re_tuning = 1;
@@ -1894,7 +1894,7 @@ int sd_switch_clock(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (re_tuning) {
 		if (CHK_SD(sd_card)) {
 			if (CHK_SD_DDR50(sd_card)) {
@@ -1913,7 +1913,7 @@ int sd_switch_clock(struct rtsx_chip *chip)
 		}
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 static int sd_prepare_reset(struct rtsx_chip *chip)
@@ -1926,12 +1926,12 @@ static int sd_prepare_reset(struct rtsx_chip *chip)
 	} else {
 		sd_card->sd_clock = CLK_30;
 	}
-	
+
 	sd_card->sd_type = 0;
 	sd_card->seq_mode = 0;
 	sd_card->sd_data_buf_ready = 0;
 	sd_card->capacity = 0;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	sd_card->sd_lock_status = 0;
 	sd_card->sd_erase_status = 0;
@@ -1944,7 +1944,7 @@ static int sd_prepare_reset(struct rtsx_chip *chip)
 		TRACE_RET(chip, retval);
 	}
 
-	RTSX_WRITE_REG(chip, SD_CFG1, 0xFF, 
+	RTSX_WRITE_REG(chip, SD_CFG1, 0xFF,
 		SD_CLK_DIVIDE_128 | SD_20_MODE | SD_BUS_WIDTH_1);
 	RTSX_WRITE_REG(chip, SD_SAMPLE_POINT_CTL, 0xFF, SD20_RX_POS_EDGE);
 	RTSX_WRITE_REG(chip, SD_PUSH_POINT_CTL, 0xFF, 0);
@@ -1955,7 +1955,7 @@ static int sd_prepare_reset(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -1966,14 +1966,14 @@ int sd_pull_ctl_disable(struct rtsx_chip *chip)
 		RTSX_WRITE_REG(chip, CARD_PULL_CTL3, 0xFF, 0xE5);
 	else
 		RTSX_WRITE_REG(chip, CARD_PULL_CTL3, 0xFF, 0xD5);
-	
+
 	return STATUS_SUCCESS;
 }
 
 int sd_pull_ctl_enable(struct rtsx_chip *chip)
 {
 	int retval;
-	
+
 	/* SD Data0~3: pull up
 	 * SD CD: pull up
 	 * SD WP: pull up
@@ -1992,36 +1992,36 @@ int sd_pull_ctl_enable(struct rtsx_chip *chip)
 	if (retval < 0) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
 static int sd_init_power(struct rtsx_chip *chip)
 {
 	int retval;
-	
+
 	RTSX_WRITE_REG(chip, PWR_GATE_CTRL, LDO3318_PWR_MASK, LDO_OFF);
-	
+
 	retval = sd_power_off_card3v3(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_change_bank_voltage(chip, SD_IO_3V3);
 	if (retval != STATUS_SUCCESS)
 		TRACE_RET(chip, STATUS_FAIL);
-	
+
 	RTSX_WRITE_REG(chip, SD30_DRIVE_SEL, 0x07, chip->sd30_drive_sel_3v3);
 
 	if (!chip->ft2_fast_mode) {
 		wait_timeout(250);
 	}
-	
+
 	retval = enable_card_clock(chip, SD_CARD);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (chip->asic_code) {
 		retval = sd_pull_ctl_enable(chip);
 		if (retval != STATUS_SUCCESS) {
@@ -2030,7 +2030,7 @@ static int sd_init_power(struct rtsx_chip *chip)
 	} else {
 		RTSX_WRITE_REG(chip, FPGA_PULL_CTL, FPGA_SD_PULL_CTL_BIT | 0x20, 0);
 	}
-	
+
 	if (chip->ft2_fast_mode) {
 		RTSX_WRITE_REG(chip, PWR_GATE_CTRL, LDO3318_PWR_MASK, LDO_ON);
 	} else {
@@ -2057,8 +2057,8 @@ static int sd_dummy_clock(struct rtsx_chip *chip)
 {
 	RTSX_WRITE_REG(chip, SD_BUS_STAT, SD_CLK_TOGGLE_EN, SD_CLK_TOGGLE_EN);
 	wait_timeout(5);
-	RTSX_WRITE_REG(chip, SD_BUS_STAT, SD_CLK_TOGGLE_EN, 0x00);			
-	
+	RTSX_WRITE_REG(chip, SD_BUS_STAT, SD_CLK_TOGGLE_EN, 0x00);
+
 	return STATUS_SUCCESS;
 }
 
@@ -2071,13 +2071,13 @@ static int sd_read_lba0(struct rtsx_chip *chip)
 	u8 cmd[5];
 #else
 	u8 *buf;
-	
+
 	buf = (u8 *)rtsx_alloc_dma_buf(chip, 512, GFP_KERNEL);
 	if (buf == NULL) {
 		TRACE_RET(chip, STATUS_ERROR);
 	}
 #endif
-	
+
 	if (CHK_SD(sd_card)) {
 		bus_width = SD_BUS_WIDTH_4;
 	} else {
@@ -2089,7 +2089,7 @@ static int sd_read_lba0(struct rtsx_chip *chip)
 			bus_width = SD_BUS_WIDTH_1;
 		}
 	}
-	
+
 #ifdef USING_PPBUF
 	cmd[0] = 0x40 | READ_SINGLE_BLOCK;
 	cmd[1] = 0;
@@ -2104,7 +2104,7 @@ static int sd_read_lba0(struct rtsx_chip *chip)
 	}
 #else
 	rtsx_init_cmd(chip);
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 0x40 | READ_SINGLE_BLOCK);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD1, 0xFF, 0);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD2, 0xFF, 0);
@@ -2118,33 +2118,33 @@ static int sd_read_lba0(struct rtsx_chip *chip)
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG1, 0x03, bus_width);
 
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, 
-			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF,
+			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 			SD_CHECK_CRC7 | SD_RSP_LEN_6);
-	
+
 	trans_dma_enable(DMA_FROM_DEVICE, chip, 512, DMA_512);
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, SD_TM_NORMAL_READ | SD_TRANSFER_START);
 	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
-	
+
 	rtsx_send_cmd_no_wait(chip);
-	
+
 	retval = rtsx_transfer_data(chip, SD_CARD, buf, 512, 0, DMA_FROM_DEVICE, 100);
 	if (retval < 0) {
 		sd_print_debug_reg(chip);
 		rtsx_free_dma_buf(chip, buf);
 		rtsx_clear_sd_error(chip);
-		
+
 		if (retval == -ETIMEDOUT) {
 			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
 
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	rtsx_free_dma_buf(chip, buf);
 #endif
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -2155,29 +2155,29 @@ static int sd_check_wp_state(struct rtsx_chip *chip)
 	u32 val;
 	u16 sd_card_type;
 	u8 cmd[5], buf[64];
-	
+
 	retval = sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	cmd[0] = 0x40 | SD_STATUS;
 	cmd[1] = 0;
 	cmd[2] = 0;
 	cmd[3] = 0;
 	cmd[4] = 0;
-	
+
 	retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, 64, 1, SD_BUS_WIDTH_4, buf, 64, 250);
 	if (retval != STATUS_SUCCESS) {
 		rtsx_clear_sd_error(chip);
-		
+
 		sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_DEBUGP(("ACMD13:\n"));
 	RTSX_DUMP(buf, 64);
-	
+
 	sd_card_type = ((u16)buf[2] << 8) | buf[3];
 	RTSX_DEBUGP(("sd_card_type = 0x%04x\n", sd_card_type));
 	if ((sd_card_type == 0x0001) || (sd_card_type == 0x0002)) {
@@ -2188,7 +2188,7 @@ static int sd_check_wp_state(struct rtsx_chip *chip)
 	if (val & SD_WRITE_PROTECT) {
 		chip->card_wp |= SD_CARD;
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -2203,9 +2203,9 @@ static int reset_sd(struct rtsx_chip *chip)
 	u32 voltage = 0;
 	int sd20_mode = chip->sd20_mode;
 	int read_lba0 = 1;
-	
+
 	RTSX_DEBUGP(("chip->sd20_mode = %d\n", chip->sd20_mode));
-	
+
 	SET_SD(sd_card);
 
 Switch_Fail:
@@ -2214,7 +2214,7 @@ Switch_Fail:
 	j = 0;
 	k = 0;
 	hi_cap_flow = 0;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if(sd_card->sd_lock_status & SD_UNLOCK_POW_ON) {
 		goto SD_UNLOCK_ENTRY;
@@ -2241,15 +2241,15 @@ RTY_SD_RST:
 
 	retval = sd_send_cmd_get_rsp(chip, SEND_IF_COND, 0x000001AA, SD_RSP_TYPE_R7, rsp, 5);
 	if (retval == STATUS_SUCCESS) {
-		if((rsp[4] == 0xAA) && ((rsp[3] & 0x0f) == 0x01)) { 
+		if((rsp[4] == 0xAA) && ((rsp[3] & 0x0f) == 0x01)) {
 			hi_cap_flow = 1;
 			if (sd20_mode) {
-				voltage = SUPPORT_VOLTAGE | 
+				voltage = SUPPORT_VOLTAGE |
 					SUPPORT_HIGH_AND_EXTENDED_CAPACITY;
 			} else {
-				voltage = SUPPORT_VOLTAGE | 
-					SUPPORT_HIGH_AND_EXTENDED_CAPACITY | 
-					SUPPORT_MAX_POWER_PERMANCE | SUPPORT_1V8; 
+				voltage = SUPPORT_VOLTAGE |
+					SUPPORT_HIGH_AND_EXTENDED_CAPACITY |
+					SUPPORT_MAX_POWER_PERMANCE | SUPPORT_1V8;
 			}
 		}
 	}
@@ -2293,7 +2293,7 @@ RTY_SD_RST:
 
 		i++;
 		wait_timeout(20);
-	} while (!(rsp[1] & 0x80) && (i < 255));  
+	} while (!(rsp[1] & 0x80) && (i < 255));
 
 	if (i == 255) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -2338,7 +2338,7 @@ RTY_SD_RST:
 
 		sd_card->sd_addr = (u32)rsp[1] << 24;
 		sd_card->sd_addr += (u32)rsp[2] << 16;
-		
+
 		if (sd_card->sd_addr) {
 			break;
 		}
@@ -2353,14 +2353,14 @@ RTY_SD_RST:
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 SD_UNLOCK_ENTRY:
 	retval = sd_update_lock_status(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if(sd_card->sd_lock_status & SD_LOCKED) {
 		sd_card->sd_lock_status |= (SD_LOCK_1BIT_MODE | SD_PWD_EXIST);
 		return STATUS_SUCCESS;
@@ -2387,18 +2387,18 @@ SD_UNLOCK_ENTRY:
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-			
+
 		switch_bus_width = SD_BUS_WIDTH_4;
-	} else {			
+	} else {
 		switch_bus_width = SD_BUS_WIDTH_1;
 	}
-	
+
 	retval = sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, 0x200, SD_RSP_TYPE_R1, NULL, 0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);	
+	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
@@ -2413,7 +2413,7 @@ SD_UNLOCK_ENTRY:
 			sd_card->sd_switch_fail = SDR104_SUPPORT_MASK |
 				DDR50_SUPPORT_MASK | SDR50_SUPPORT_MASK;
 		}
-		
+
 		retval = sd_check_spec(chip, switch_bus_width);
 		if (retval == STATUS_SUCCESS) {
 			retval = sd_switch_function(chip, switch_bus_width);
@@ -2428,7 +2428,7 @@ SD_UNLOCK_ENTRY:
 			}
 		}
 	}
-	
+
 	if (support_1v8) {
 		RTSX_WRITE_REG(chip, SD30_DRIVE_SEL, 0x07, chip->sd30_drive_sel_1v8);
 	} else {
@@ -2439,9 +2439,9 @@ SD_UNLOCK_ENTRY:
 		retval = sd_send_cmd_get_rsp(chip, SET_BUS_WIDTH, 2, SD_RSP_TYPE_R1, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
-		}		
+		}
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	sd_card->sd_lock_status &= ~SD_LOCK_1BIT_MODE;
 #endif
@@ -2460,16 +2460,16 @@ SD_UNLOCK_ENTRY:
 
 		if (retval != STATUS_SUCCESS)
 			goto SD20_MODE;
-		
+
 		sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
-		
+
 		if (CHK_SD_DDR50(sd_card)) {
 			retval = sd_wait_state_data_ready(chip, 0x08, 1, 1000);
 			if (retval != STATUS_SUCCESS) {
 				read_lba0 = 0;
 			}
 		}
-	
+
 		if (read_lba0) {
 			retval = sd_read_lba0(chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2488,7 +2488,7 @@ SD_UNLOCK_ENTRY:
 	}
 
 	chip->card_bus_width[chip->card2lun[SD_CARD]] = 4;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if(sd_card->sd_lock_status & SD_UNLOCK_POW_ON) {
 		RTSX_WRITE_REG(chip, SD_BLOCK_CNT_H, 0xFF, 0x02);
@@ -2527,7 +2527,7 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (width == MMC_8BIT_BUS) {
 		buf[0] = 0x55;
 		buf[1] = 0xAA;
@@ -2540,7 +2540,7 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 		byte_cnt = 4;
 		bus_width = SD_BUS_WIDTH_4;
 	}
-	
+
 	retval = sd_write_data(chip, SD_TM_AUTO_WRITE_3,
 			NULL, 0, byte_cnt, 1, bus_width, buf, len, 100);
 	if (retval != STATUS_SUCCESS) {
@@ -2552,11 +2552,11 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	}
-	
+
 	RTSX_DEBUGP(("SD/MMC CMD %d\n", BUSTEST_R));
-	
+
 	rtsx_init_cmd(chip);
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 0x40 | BUSTEST_R);
 
 	if (width == MMC_8BIT_BUS) {
@@ -2568,8 +2568,8 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L, 0xFF, 1);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H, 0xFF, 0);
 
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, 
-			SD_CALCULATE_CRC7 | SD_NO_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF,
+			SD_CALCULATE_CRC7 | SD_NO_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 			SD_CHECK_CRC7 | SD_RSP_LEN_6);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE, 0x01, PINGPONG_BUFFER);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, SD_TM_NORMAL_READ | SD_TRANSFER_START);
@@ -2585,15 +2585,15 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 		rtsx_clear_sd_error(chip);
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	ptr = rtsx_get_cmd_data(chip) + 1;
-	
+
 	if (width == MMC_8BIT_BUS) {
 		RTSX_DEBUGP(("BUSTEST_R [8bits]: 0x%02x 0x%02x\n", ptr[0], ptr[1]));
 		if ((ptr[0] == 0xAA) && (ptr[1] == 0x55)) {
 			u8 rsp[5];
 			u32 arg;
-			
+
 			if (CHK_MMC_DDR52(sd_card)) {
 				arg = 0x03B70600;
 			} else {
@@ -2609,7 +2609,7 @@ static int mmc_test_switch_bus(struct rtsx_chip *chip, u8 width)
 		if (ptr[0] == 0xA5) {
 			u8 rsp[5];
 			u32 arg;
-			
+
 			if (CHK_MMC_DDR52(sd_card)) {
 				arg = 0x03B70500;
 			} else {
@@ -2633,7 +2633,7 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 	u8 *ptr, card_type, card_type_mask = 0;
 #ifndef USING_PPBUF
 	u8 *buf;
-	
+
 	buf = (u8 *)rtsx_alloc_dma_buf(chip, 512, GFP_KERNEL);
 	if (buf == NULL) {
 		TRACE_RET(chip, STATUS_ERROR);
@@ -2643,7 +2643,7 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 	CLR_MMC_HS(sd_card);
 
 	RTSX_DEBUGP(("SD/MMC CMD %d\n", SEND_EXT_CSD));
-	
+
 	rtsx_init_cmd(chip);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 0x40 | SEND_EXT_CSD);
@@ -2657,46 +2657,46 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L, 0xFF, 1);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H, 0xFF, 0);
 
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, 
-			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF,
+			SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 			SD_CHECK_CRC7 | SD_RSP_LEN_6);
-	
+
 #ifdef USING_PPBUF
 	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE, 0x01, PINGPONG_BUFFER);
 #else
 	trans_dma_enable(DMA_FROM_DEVICE, chip, 512, DMA_512);
 #endif
-	
+
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, SD_TM_NORMAL_READ | SD_TRANSFER_START);
 	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
-	
+
 #ifdef USING_PPBUF
-	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 196, 0xFF, 0);  
-	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 212, 0xFF, 0);  
-	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 213, 0xFF, 0);  
-	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 214, 0xFF, 0);  
-	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 215, 0xFF, 0);  
+	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 196, 0xFF, 0);
+	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 212, 0xFF, 0);
+	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 213, 0xFF, 0);
+	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 214, 0xFF, 0);
+	rtsx_add_cmd(chip, READ_REG_CMD, PPBUF_BASE2 + 215, 0xFF, 0);
 
 	retval = rtsx_send_cmd(chip, SD_CARD, 1000);
 	if (retval < 0) {
 		if (retval == -ETIMEDOUT) {
 			rtsx_clear_sd_error(chip);
 
-			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 					SD_RSP_TYPE_R1, NULL, 0);
 		}
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 #else
 	rtsx_send_cmd_no_wait(chip);
-	
+
 	retval = rtsx_transfer_data(chip, SD_CARD, buf, 512, 0, DMA_FROM_DEVICE, 100);
 	if (retval < 0) {
 		rtsx_free_dma_buf(chip, buf);
 		if (retval == -ETIMEDOUT) {
 			rtsx_clear_sd_error(chip);
 
-			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+			sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 					SD_RSP_TYPE_R1, NULL, 0);
 		}
 		TRACE_RET(chip, STATUS_FAIL);
@@ -2721,7 +2721,7 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 	}
 
 #ifdef SUPPORT_SD_LOCK
-	if (!(sd_card->sd_lock_status & SD_SDR_RST) && 
+	if (!(sd_card->sd_lock_status & SD_SDR_RST) &&
 			(chip->sd_ctl & SUPPORT_MMC_DDR_MODE)) {
 		card_type_mask = 0x07;
 	} else {
@@ -2739,18 +2739,18 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 #else
 	card_type = buf[196] & card_type_mask;
 #endif
-	if (card_type) {   
+	if (card_type) {
 		u8 rsp[5];
-		
-		if (card_type & 0x04) {  
+
+		if (card_type & 0x04) {
 			if (switch_ddr) {
 				SET_MMC_DDR52(sd_card);
 			} else {
 				SET_MMC_52M(sd_card);
 			}
-		} else if (card_type & 0x02) {  
+		} else if (card_type & 0x02) {
 			SET_MMC_52M(sd_card);
-		} else {  
+		} else {
 			SET_MMC_26M(sd_card);
 		}
 
@@ -2759,7 +2759,7 @@ static int mmc_switch_timing_bus(struct rtsx_chip *chip, int switch_ddr)
 			CLR_MMC_HS(sd_card);
 		}
 	}
-	
+
 #ifndef USING_PPBUF
 	rtsx_free_dma_buf(chip, buf);
 #endif
@@ -2811,7 +2811,7 @@ DDR_TUNING_FAIL:
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, retval);
 	}
-	
+
 	SET_MMC(sd_card);
 
 RTY_MMC_RST:
@@ -2825,8 +2825,8 @@ RTY_MMC_RST:
 			sd_set_err_code(chip, SD_NO_CARD);
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-			
-		retval = sd_send_cmd_get_rsp(chip, SEND_OP_COND, 
+
+		retval = sd_send_cmd_get_rsp(chip, SEND_OP_COND,
 				(SUPPORT_VOLTAGE|0x40000000), SD_RSP_TYPE_R3, rsp, 5);
 		if (retval != STATUS_SUCCESS) {
 			if (sd_check_err_code(chip, SD_BUSY) || sd_check_err_code(chip, SD_TO_ERR)) {
@@ -2850,7 +2850,7 @@ RTY_MMC_RST:
 
 		wait_timeout(20);
 		i++;
-	} while(!(rsp[1] & 0x80) && (i < 255));   
+	} while(!(rsp[1] & 0x80) && (i < 255));
 
 	if (i == 255) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -2891,7 +2891,7 @@ RTY_MMC_RST:
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 MMC_UNLOCK_ENTRY:
 	retval = sd_update_lock_status(chip);
@@ -2899,24 +2899,24 @@ MMC_UNLOCK_ENTRY:
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 #endif
-	
-	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);	
+
+	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
 	chip->card_bus_width[chip->card2lun[SD_CARD]] = 1;
-	
+
 	if (!sd_card->mmc_dont_switch_bus) {
-		
-		if (spec_ver == 4) {  
+
+		if (spec_ver == 4) {
 			(void)mmc_switch_timing_bus(chip, switch_ddr);
 		}
 
 		if (CHK_MMC_SECTOR_MODE(sd_card) && (sd_card->capacity == 0)) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		if (switch_ddr && CHK_MMC_DDR52(sd_card)) {
 			retval = sd_set_init_para(chip);
 			if (retval != STATUS_SUCCESS) {
@@ -2932,7 +2932,7 @@ MMC_UNLOCK_ENTRY:
 				switch_ddr = 0;
 				goto DDR_TUNING_FAIL;
 			}
-			
+
 			retval = sd_wait_state_data_ready(chip, 0x08, 1, 1000);
 			if (retval == STATUS_SUCCESS) {
 				retval = sd_read_lba0(chip);
@@ -2947,7 +2947,7 @@ MMC_UNLOCK_ENTRY:
 			}
 		}
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if(sd_card->sd_lock_status & SD_UNLOCK_POW_ON) {
 		RTSX_WRITE_REG(chip, SD_BLOCK_CNT_H, 0xFF, 0x02);
@@ -2967,7 +2967,7 @@ int reset_sd_card(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
-	
+
 	memset(sd_card, 0, sizeof(struct sd_info));
 	chip->capacity[chip->card2lun[SD_CARD]] = 0;
 
@@ -2999,12 +2999,12 @@ int reset_sd_card(struct rtsx_chip *chip)
 				if (sd_check_err_code(chip, SD_NO_CARD)) {
 					TRACE_RET(chip, STATUS_FAIL);
 				}
-				
+
 				retval = sd_change_bank_voltage(chip, SD_IO_3V3);
 				if (retval != STATUS_SUCCESS) {
 					TRACE_RET(chip, STATUS_FAIL);
 				}
-				
+
 				retval = reset_mmc(chip);
 			}
 		}
@@ -3019,21 +3019,21 @@ int reset_sd_card(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 	RTSX_WRITE_REG(chip, SD_BYTE_CNT_L, 0xFF, 0);
 	RTSX_WRITE_REG(chip, SD_BYTE_CNT_H, 0xFF, 2);
-	
+
 	chip->capacity[chip->card2lun[SD_CARD]] = sd_card->capacity;
 
 	retval = sd_set_init_para(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_DEBUGP(("sd_card->sd_type = 0x%x\n", sd_card->sd_type));
 
 	return STATUS_SUCCESS;
@@ -3043,13 +3043,13 @@ static int reset_mmc_only(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
-	
+
 	sd_card->sd_type = 0;
 	sd_card->seq_mode = 0;
 	sd_card->sd_data_buf_ready = 0;
 	sd_card->capacity = 0;
 	sd_card->sd_switch_fail = 0;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	sd_card->sd_lock_status = 0;
 	sd_card->sd_erase_status = 0;
@@ -3066,26 +3066,26 @@ static int reset_mmc_only(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = reset_mmc(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_set_clock_divider(chip, SD_CLK_DIVIDE_0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 	RTSX_WRITE_REG(chip, SD_BYTE_CNT_L, 0xFF, 0);
 	RTSX_WRITE_REG(chip, SD_BYTE_CNT_H, 0xFF, 2);
-	
+
 	chip->capacity[chip->card2lun[SD_CARD]] = sd_card->capacity;
 
 	retval = sd_set_init_para(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_DEBUGP(("In reset_mmc_only, sd_card->sd_type = 0x%x\n", sd_card->sd_type));
 
 	return STATUS_SUCCESS;
@@ -3096,7 +3096,7 @@ static int reset_mmc_only(struct rtsx_chip *chip)
 static int wait_data_buf_ready(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
-	int i, retval; 
+	int i, retval;
 
 	for (i = 0; i < WAIT_DATA_READY_RTY_CNT; i++) {
 		if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
@@ -3105,15 +3105,15 @@ static int wait_data_buf_ready(struct rtsx_chip *chip)
 		}
 
 		sd_card->sd_data_buf_ready = 0;
-		
-		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+
+		retval = sd_send_cmd_get_rsp(chip, SEND_STATUS,
 				sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 
 		if (sd_card->sd_data_buf_ready) {
-			return sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+			return sd_send_cmd_get_rsp(chip, SEND_STATUS,
 				sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
 	}
@@ -3134,7 +3134,7 @@ void sd_stop_seq_mode(struct rtsx_chip *chip)
 			return;
 		}
 
-		retval = sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 0, 
+		retval = sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 0,
 				SD_RSP_TYPE_R1b, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			sd_set_err_code(chip, SD_STS_ERR);
@@ -3144,7 +3144,7 @@ void sd_stop_seq_mode(struct rtsx_chip *chip)
 			sd_set_err_code(chip, SD_STS_ERR);
 		}
 		sd_card->seq_mode = 0;
-		
+
 		rtsx_write_register(chip, RBCTL, RB_FLUSH, RB_FLUSH);
 	}
 }
@@ -3163,37 +3163,37 @@ static inline int sd_auto_tune_clock(struct rtsx_chip *chip)
 		case CLK_200:
 			sd_card->sd_clock = CLK_150;
 			break;
-			
+
 		case CLK_150:
 			sd_card->sd_clock = CLK_120;
 			break;
-			
+
 		case CLK_120:
 			sd_card->sd_clock = CLK_100;
 			break;
-			
+
 		case CLK_100:
 			sd_card->sd_clock = CLK_80;
 			break;
-			
+
 		case CLK_80:
 			sd_card->sd_clock = CLK_60;
 			break;
-			
+
 		case CLK_60:
 			sd_card->sd_clock = CLK_50;
 			break;
-			
+
 		default:
 			break;
 		}
 	}
-	
+
 	retval = sd_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -3204,13 +3204,13 @@ static int sd_stop_sequential(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
-	
-	if ((sd_card->pre_sec_cnt < 0x80) 	
+
+	if ((sd_card->pre_sec_cnt < 0x80)
 			&& (sd_card->pre_dir == DMA_FROM_DEVICE)
-			&& !CHK_SD30_SPEED(sd_card) 
+			&& !CHK_SD30_SPEED(sd_card)
 			&& !CHK_SD_HS(sd_card)
 			&& !CHK_MMC_HS(sd_card)) {
-		sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+		sd_send_cmd_get_rsp(chip, SEND_STATUS,
 				sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 	}
 
@@ -3227,38 +3227,38 @@ static int sd_stop_sequential(struct rtsx_chip *chip)
 		TRACE_RET(chip, STATUS_FAIL);
 	}
 
-	if ((sd_card->pre_sec_cnt < 0x80) 
-			&& !CHK_SD30_SPEED(sd_card) 
+	if ((sd_card->pre_sec_cnt < 0x80)
+			&& !CHK_SD30_SPEED(sd_card)
 			&& !CHK_SD_HS(sd_card)
 			&& !CHK_MMC_HS(sd_card)) {
-		sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+		sd_send_cmd_get_rsp(chip, SEND_STATUS,
 				sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
 static inline int sd_in_seq(struct sd_info *sd_card,
 			u32 start_sector, enum dma_data_direction data_dir)
 {
-	if (sd_card->pre_dir != data_dir) 
+	if (sd_card->pre_dir != data_dir)
 		return 0;
-	if ((sd_card->pre_sec_addr + sd_card->pre_sec_cnt) != start_sector) 
+	if ((sd_card->pre_sec_addr + sd_card->pre_sec_cnt) != start_sector)
 		return 0;
-	
+
 	return 1;
 }
 
 static inline u32 sd_calc_data_addr(struct sd_info *sd_card, u32 start_sector)
 {
 	u32 data_addr;
-	
+
 	if (!CHK_SD_HCXC(sd_card) && !CHK_MMC_SECTOR_MODE(sd_card)) {
 		data_addr = start_sector << 9;
 	} else {
 		data_addr = start_sector;
 	}
-	
+
 	return data_addr;
 }
 
@@ -3266,7 +3266,7 @@ static void sd_auto_read2(struct rtsx_chip *chip, u32 data_addr, u16 sector_cnt)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	u8 cfg2;
-	
+
 	rtsx_init_cmd(chip);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, 0x00);
@@ -3283,7 +3283,7 @@ static void sd_auto_read2(struct rtsx_chip *chip, u32 data_addr, u16 sector_cnt)
 	} else {
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG1, 0x03, SD_BUS_WIDTH_1);
 	}
-	
+
 	RTSX_DEBUGP(("SD/MMC CMD %d\n", READ_MULTIPLE_BLOCK));
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 0x40 | READ_MULTIPLE_BLOCK);
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD1, 0xFF, (u8)(data_addr >> 24));
@@ -3312,18 +3312,18 @@ static int sd_write(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sec
 	u32 data_addr;
 	u8 cfg2;
 	int retval;
-	
+
 	data_addr = sd_calc_data_addr(sd_card, start_sector);
-	
+
 	if (sd_card->seq_mode && !sd_in_seq(sd_card, start_sector, srb->sc_data_direction)) {
 		retval = sd_stop_sequential(chip);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		sd_card->seq_mode = 0;
 	}
-	
+
 	rtsx_init_cmd(chip);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, 0x00);
@@ -3342,7 +3342,7 @@ static int sd_write(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sec
 	}
 
 	if (sd_card->seq_mode) {
-		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 				SD_NO_CHECK_CRC7 | SD_RSP_LEN_0;
 		if (!CHK_SD30_SPEED(sd_card)) {
 			cfg2 |= SD_NO_CHECK_WAIT_CRC_TO;
@@ -3350,8 +3350,8 @@ static int sd_write(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sec
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, cfg2);
 
 		trans_dma_enable(srb->sc_data_direction, chip, sector_cnt * 512, DMA_512);
-		
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 			     SD_TM_AUTO_WRITE_3 | SD_TRANSFER_START);
 
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
@@ -3374,16 +3374,16 @@ static int sd_write(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sec
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 
-		retval = sd_send_cmd_get_rsp(chip, WRITE_MULTIPLE_BLOCK, 
+		retval = sd_send_cmd_get_rsp(chip, WRITE_MULTIPLE_BLOCK,
 				data_addr, SD_RSP_TYPE_R1, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			chip->rw_need_retry = 1;
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		rtsx_init_cmd(chip);
 
-		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 				SD_NO_CHECK_CRC7 | SD_RSP_LEN_0;
 		if (!CHK_SD30_SPEED(sd_card)) {
 			cfg2 |= SD_NO_CHECK_WAIT_CRC_TO;
@@ -3392,16 +3392,16 @@ static int sd_write(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sec
 
 		trans_dma_enable(srb->sc_data_direction, chip, sector_cnt * 512, DMA_512);
 
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 				SD_TM_AUTO_WRITE_3 | SD_TRANSFER_START);
-		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, 
+		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER,
 				SD_TRANSFER_END, SD_TRANSFER_END);
 
 		rtsx_send_cmd_no_wait(chip);
 
 		sd_card->seq_mode = 1;
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -3410,12 +3410,12 @@ static int sd_read(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sect
 	struct sd_info *sd_card = &(chip->sd_card);
 	u32 data_addr;
 	int retval;
-	
+
 	data_addr = sd_calc_data_addr(sd_card, start_sector);
-	
+
 	if (sd_card->seq_mode) {
 		int stop = 0;
-		
+
 		if (sd_in_seq(sd_card, start_sector, srb->sc_data_direction)) {
 			if ((sd_card->total_sec_cnt + sector_cnt) > PRE_READ_30M) {
 				rtsx_wait_rb_full(chip);
@@ -3424,20 +3424,20 @@ static int sd_read(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sect
 		} else {
 			stop = 1;
 		}
-		
+
 		if (stop) {
 			retval = sd_stop_sequential(chip);
 			if (retval != STATUS_SUCCESS) {
 				TRACE_RET(chip, STATUS_FAIL);
 			}
-			
+
 			sd_card->seq_mode = 0;
 		}
 	}
-	
+
 	if (!sd_card->seq_mode) {
 		sd_card->total_sec_cnt = 0;
-		
+
 		if (sector_cnt >= PRE_READ_TH) {
 			sd_auto_read2(chip, data_addr, PRE_READ_30M);
 			sd_card->seq_mode = 1;
@@ -3453,20 +3453,20 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
-	
+
 	if (srb->sc_data_direction == DMA_FROM_DEVICE) {
-		RTSX_DEBUGP(("sd_rw: Read %d %s from 0x%x\n", sector_cnt, 
+		RTSX_DEBUGP(("sd_rw: Read %d %s from 0x%x\n", sector_cnt,
 			     (sector_cnt > 1) ? "sectors" : "sector", start_sector));
 	} else {
-		RTSX_DEBUGP(("sd_rw: Write %d %s to 0x%x\n", sector_cnt, 
+		RTSX_DEBUGP(("sd_rw: Write %d %s to 0x%x\n", sector_cnt,
 			     (sector_cnt > 1) ? "sectors" : "sector", start_sector));
 	}
 
 	sd_card->cleanup_counter = 0;
-	
+
 	if (!(chip->card_ready & SD_CARD)) {
 		sd_card->seq_mode = 0;
-		
+
 		retval = reset_sd_card(chip);
 		if (retval == STATUS_SUCCESS) {
 			chip->card_ready |= SD_CARD;
@@ -3487,7 +3487,7 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 		sd_set_err_code(chip, SD_IO_ERR);
 		TRACE_GOTO(chip, RW_FAIL);
 	}
-	
+
 	if (srb->sc_data_direction == DMA_FROM_DEVICE) {
 		retval = sd_read(srb, chip, start_sector, sector_cnt);
 	} else {
@@ -3497,34 +3497,34 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 		TRACE_GOTO(chip, RW_FAIL);
 	}
 
-	retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb), 
+	retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb),
 			scsi_sg_count(srb), srb->sc_data_direction, chip->sd_timeout);
 	if (retval < 0) {
 		u8 stat = 0;
 		int err;
-		
+
 		sd_card->seq_mode = 0;
-		
+
 		if (retval == -ETIMEDOUT) {
 			err = STATUS_TIMEDOUT;
 		} else {
 			err = STATUS_FAIL;
 		}
-		
+
 		sd_print_debug_reg(chip);
-		
+
 		CATCH_TRIGGER1(chip);
-		
+
 		rtsx_read_register(chip, SD_STAT1, &stat);
 
 		rtsx_clear_sd_error(chip);
-		
+
 		if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 			chip->rw_need_retry = 0;
 			RTSX_DEBUGP(("No card exist, exit sd_rw\n"));
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		retval = sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 0, SD_RSP_TYPE_R1b, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			chip->rw_need_retry = 1;
@@ -3544,7 +3544,7 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 			sd_set_err_code(chip, SD_TO_ERR);
 			TRACE_GOTO(chip, RW_FAIL);
 		}
-		
+
 		TRACE_RET(chip, err);
 	}
 
@@ -3560,21 +3560,21 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 			TRACE_GOTO(chip, RW_FAIL);
 		}
 	}
-	
+
 	return STATUS_SUCCESS;
 
-RW_FAIL:	
+RW_FAIL:
 	sd_card->seq_mode = 0;
-	
+
 	if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 		chip->rw_need_retry = 0;
 		RTSX_DEBUGP(("No card exist, exit sd_rw\n"));
 	}
-	
+
 	if (!chip->rw_need_retry) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (sd_check_err_code(chip,SD_CRC_ERR)) {
 		if (CHK_MMC_4BIT(sd_card) || CHK_MMC_8BIT(sd_card)) {
 			sd_card->mmc_dont_switch_bus = 1;
@@ -3601,11 +3601,11 @@ RW_FAIL:
 			chip->capacity[chip->card2lun[SD_CARD]] = 0;
 		}
 	}
-	
+
 	TRACE_RET(chip, STATUS_FAIL);
 }
 
-#else   
+#else
 
 int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 sector_cnt)
 {
@@ -3613,20 +3613,20 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 	u32 data_addr;
 	u8 cfg2;
 	int retval;
-	
+
 	if (srb->sc_data_direction == DMA_FROM_DEVICE) {
-		RTSX_DEBUGP(("sd_rw: Read %d %s from 0x%x\n", sector_cnt, 
+		RTSX_DEBUGP(("sd_rw: Read %d %s from 0x%x\n", sector_cnt,
 			     (sector_cnt > 1) ? "sectors" : "sector", start_sector));
 	} else {
-		RTSX_DEBUGP(("sd_rw: Write %d %s to 0x%x\n", sector_cnt, 
+		RTSX_DEBUGP(("sd_rw: Write %d %s to 0x%x\n", sector_cnt,
 			     (sector_cnt > 1) ? "sectors" : "sector", start_sector));
 	}
 
 	sd_card->cleanup_counter = 0;
-	
+
 	if (!(chip->card_ready & SD_CARD)) {
 		sd_card->seq_mode = 0;
-		
+
 		retval = reset_sd_card(chip);
 		if (retval == STATUS_SUCCESS) {
 			chip->card_ready |= SD_CARD;
@@ -3654,14 +3654,14 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 		TRACE_GOTO(chip, RW_FAIL);
 	}
 
-	if (sd_card->seq_mode && ((sd_card->pre_dir != srb->sc_data_direction) 
+	if (sd_card->seq_mode && ((sd_card->pre_dir != srb->sc_data_direction)
 			|| ((sd_card->pre_sec_addr + sd_card->pre_sec_cnt) != start_sector ))) {
-		if ((sd_card->pre_sec_cnt < 0x80) 	
+		if ((sd_card->pre_sec_cnt < 0x80)
 				&& (sd_card->pre_dir == DMA_FROM_DEVICE)
-				&& !CHK_SD30_SPEED(sd_card) 
+				&& !CHK_SD30_SPEED(sd_card)
 				&& !CHK_SD_HS(sd_card)
 				&& !CHK_MMC_HS(sd_card)) {
-			sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+			sd_send_cmd_get_rsp(chip, SEND_STATUS,
 					sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
 
@@ -3680,15 +3680,15 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 			TRACE_GOTO(chip, RW_FAIL);
 		}
 
-		if ((sd_card->pre_sec_cnt < 0x80) 
-				&& !CHK_SD30_SPEED(sd_card) 
+		if ((sd_card->pre_sec_cnt < 0x80)
+				&& !CHK_SD30_SPEED(sd_card)
 				&& !CHK_SD_HS(sd_card)
 				&& !CHK_MMC_HS(sd_card)) {
-			sd_send_cmd_get_rsp(chip, SEND_STATUS, 
+			sd_send_cmd_get_rsp(chip, SEND_STATUS,
 					sd_card->sd_addr, SD_RSP_TYPE_R1, NULL, 0);
 		}
 	}
-	
+
 	rtsx_init_cmd(chip);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, 0x00);
@@ -3707,7 +3707,7 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 	}
 
 	if (sd_card->seq_mode) {
-		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+		cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 				SD_NO_CHECK_CRC7 | SD_RSP_LEN_0;
 		if (!CHK_SD30_SPEED(sd_card)) {
 			cfg2 |= SD_NO_CHECK_WAIT_CRC_TO;
@@ -3715,12 +3715,12 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, cfg2);
 
 		trans_dma_enable(srb->sc_data_direction, chip, sector_cnt * 512, DMA_512);
-		
+
 		if (srb->sc_data_direction == DMA_FROM_DEVICE) {
-			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 				     SD_TM_AUTO_READ_3 | SD_TRANSFER_START);
 		} else {
-			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 				     SD_TM_AUTO_WRITE_3 | SD_TRANSFER_START);
 		}
 
@@ -3730,14 +3730,14 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 	} else {
 		if (srb->sc_data_direction == DMA_FROM_DEVICE) {
 			RTSX_DEBUGP(("SD/MMC CMD %d\n", READ_MULTIPLE_BLOCK));
-			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 
+			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF,
 				     0x40 | READ_MULTIPLE_BLOCK);
 			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD1, 0xFF, (u8)(data_addr >> 24));
 			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD2, 0xFF, (u8)(data_addr >> 16));
 			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD3, 0xFF, (u8)(data_addr >> 8));
 			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD4, 0xFF, (u8)data_addr);
 
-			cfg2 = SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+			cfg2 = SD_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 					SD_CHECK_CRC7 | SD_RSP_LEN_6;
 			if (!CHK_SD30_SPEED(sd_card)) {
 				cfg2 |= SD_NO_CHECK_WAIT_CRC_TO;
@@ -3746,9 +3746,9 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 
 			trans_dma_enable(srb->sc_data_direction, chip, sector_cnt * 512, DMA_512);
 
-			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 				     SD_TM_AUTO_READ_2 | SD_TRANSFER_START);
-			rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, 
+			rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER,
 				     SD_TRANSFER_END, SD_TRANSFER_END);
 
 			rtsx_send_cmd_no_wait(chip);
@@ -3769,16 +3769,16 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 				TRACE_GOTO(chip, RW_FAIL);
 			}
 
-			retval = sd_send_cmd_get_rsp(chip, WRITE_MULTIPLE_BLOCK, 
+			retval = sd_send_cmd_get_rsp(chip, WRITE_MULTIPLE_BLOCK,
 					data_addr, SD_RSP_TYPE_R1, NULL, 0);
 			if (retval != STATUS_SUCCESS) {
 				chip->rw_need_retry = 1;
 				TRACE_GOTO(chip, RW_FAIL);
 			}
-			
+
 			rtsx_init_cmd(chip);
 
-			cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END | 
+			cfg2 = SD_NO_CALCULATE_CRC7 | SD_CHECK_CRC16 | SD_NO_WAIT_BUSY_END |
 					SD_NO_CHECK_CRC7 | SD_RSP_LEN_0;
 			if (!CHK_SD30_SPEED(sd_card)) {
 				cfg2 |= SD_NO_CHECK_WAIT_CRC_TO;
@@ -3787,9 +3787,9 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 
 			trans_dma_enable(srb->sc_data_direction, chip, sector_cnt * 512, DMA_512);
 
-			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, 
+			rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF,
 				     SD_TM_AUTO_WRITE_3 | SD_TRANSFER_START);
-			rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, 
+			rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER,
 				     SD_TRANSFER_END, SD_TRANSFER_END);
 
 			rtsx_send_cmd_no_wait(chip);
@@ -3798,34 +3798,34 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 		sd_card->seq_mode = 1;
 	}
 
-	retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb), 
+	retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb),
 			scsi_sg_count(srb), srb->sc_data_direction, chip->sd_timeout);
 	if (retval < 0) {
 		u8 stat = 0;
 		int err;
-		
+
 		sd_card->seq_mode = 0;
-		
+
 		if (retval == -ETIMEDOUT) {
 			err = STATUS_TIMEDOUT;
 		} else {
 			err = STATUS_FAIL;
 		}
-		
+
 		sd_print_debug_reg(chip);
-		
+
 		CATCH_TRIGGER1(chip);
-		
+
 		rtsx_read_register(chip, SD_STAT1, &stat);
 
 		rtsx_clear_sd_error(chip);
-		
+
 		if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 			chip->rw_need_retry = 0;
 			RTSX_DEBUGP(("No card exist, exit sd_rw\n"));
 			TRACE_GOTO(chip, RW_FAIL);
 		}
-		
+
 		retval = sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 0, SD_RSP_TYPE_R1b, NULL, 0);
 		if (retval != STATUS_SUCCESS) {
 			chip->rw_need_retry = 1;
@@ -3845,28 +3845,28 @@ int sd_rw(struct scsi_cmnd *srb, struct rtsx_chip *chip, u32 start_sector, u16 s
 			sd_set_err_code(chip, SD_TO_ERR);
 			TRACE_GOTO(chip, RW_FAIL);
 		}
-		
+
 		TRACE_RET(chip, err);
 	}
-	
+
 	sd_card->pre_sec_addr = start_sector;
 	sd_card->pre_sec_cnt = sector_cnt;
 	sd_card->pre_dir = srb->sc_data_direction;
-	
+
 	return STATUS_SUCCESS;
 
-RW_FAIL:	
+RW_FAIL:
 	sd_card->seq_mode = 0;
-	
+
 	if (detect_card_cd(chip, SD_CARD) != STATUS_SUCCESS) {
 		chip->rw_need_retry = 0;
 		RTSX_DEBUGP(("No card exist, exit sd_rw\n"));
 	}
-	
+
 	if (!chip->rw_need_retry) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	if (sd_check_err_code(chip,SD_CRC_ERR)) {
 		if (CHK_MMC_4BIT(sd_card) || CHK_MMC_8BIT(sd_card)) {
 			sd_card->mmc_dont_switch_bus = 1;
@@ -3893,11 +3893,11 @@ RW_FAIL:
 			chip->capacity[chip->card2lun[SD_CARD]] = 0;
 		}
 	}
-	
+
 	TRACE_RET(chip, STATUS_FAIL);
 }
 
-#endif  
+#endif
 
 #ifdef SUPPORT_CPRM
 int soft_reset_sd_card(struct rtsx_chip *chip)
@@ -3905,7 +3905,7 @@ int soft_reset_sd_card(struct rtsx_chip *chip)
 	return reset_sd(chip);
 }
 
-int ext_sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx, 
+int ext_sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx,
 		u32 arg, u8 rsp_type, u8 *rsp, int rsp_len, int special_check)
 {
 	int retval;
@@ -3932,9 +3932,9 @@ RTY_SEND_CMD:
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD4, 0xFF, (u8)arg);
 
 	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CFG2, 0xFF, rsp_type);
-	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE, 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, CARD_DATA_SOURCE,
 			0x01, PINGPONG_BUFFER);
-	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 
+	rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER,
 			0xFF, SD_TM_CMD_RSP | SD_TRANSFER_START);
 	rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
 
@@ -3948,7 +3948,7 @@ RTY_SEND_CMD:
 			rtsx_add_cmd(chip, READ_REG_CMD, reg_addr, 0, 0);
 		}
 		stat_idx = 6;
-	} 
+	}
 	rtsx_add_cmd(chip, READ_REG_CMD, SD_CMD5, 0, 0);
 
 	rtsx_add_cmd(chip, READ_REG_CMD, SD_STAT1, 0, 0);
@@ -3974,7 +3974,7 @@ RTY_SEND_CMD:
 		return STATUS_SUCCESS;
 	}
 
-	ptr = rtsx_get_cmd_data(chip) + 1;  
+	ptr = rtsx_get_cmd_data(chip) + 1;
 
 	if ((ptr[0] & 0xC0) != 0) {
 		sd_set_err_code(chip, SD_STS_ERR);
@@ -3998,7 +3998,7 @@ RTY_SEND_CMD:
 		}
 	}
 
-	if ((cmd_idx == SELECT_CARD) || (cmd_idx == APP_CMD) || 
+	if ((cmd_idx == SELECT_CARD) || (cmd_idx == APP_CMD) ||
 			(cmd_idx == SEND_STATUS) || (cmd_idx == STOP_TRANSMISSION)) {
 		if ((cmd_idx != STOP_TRANSMISSION) && (special_check == 0)) {
 			if (ptr[1] & 0x80) {
@@ -4006,7 +4006,7 @@ RTY_SEND_CMD:
 			}
 		}
 #ifdef SUPPORT_SD_LOCK
-		if (ptr[1] & 0x7D) 
+		if (ptr[1] & 0x7D)
 #else
 		if (ptr[1] & 0x7F)
 #endif
@@ -4016,7 +4016,7 @@ RTY_SEND_CMD:
 		if (ptr[2] & 0xF8) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		if (cmd_idx == SELECT_CARD) {
 			if (rsp_type == SD_RSP_TYPE_R2) {
 				if ((ptr[3] & 0x1E) != 0x04) {
@@ -4072,11 +4072,11 @@ int ext_sd_get_rsp(struct rtsx_chip *chip, int len, u8 *rsp, u8 rsp_type)
 		memcpy(rsp, rtsx_get_cmd_data(chip), min_len);
 
 		RTSX_DEBUGP(("min_len = %d\n", min_len));
-		RTSX_DEBUGP(("Response in cmd buf: 0x%x 0x%x 0x%x 0x%x\n", 
+		RTSX_DEBUGP(("Response in cmd buf: 0x%x 0x%x 0x%x 0x%x\n",
 			rsp[0], rsp[1], rsp[2], rsp[3]));
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 int sd_pass_thru_mode(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -4089,18 +4089,18 @@ int sd_pass_thru_mode(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		0x00,
 		0x00,
 		0x0E,
-		0x00,	
-		0x00,	
-		0x00,	
-		0x00,	
-		0x53,	
-		0x44,	
-		0x20,	
-		0x43,	
-		0x61,	
-		0x72,	
-		0x64,	
-		0x00,	
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x53,
+		0x44,
+		0x20,
+		0x43,
+		0x61,
+		0x72,
+		0x64,
+		0x00,
 		0x00,
 		0x00,
 	};
@@ -4113,8 +4113,8 @@ int sd_pass_thru_mode(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
-	if ((0x53 != srb->cmnd[2]) || (0x44 != srb->cmnd[3]) || (0x20 != srb->cmnd[4]) || 
-			(0x43 != srb->cmnd[5]) || (0x61 != srb->cmnd[6]) || 
+	if ((0x53 != srb->cmnd[2]) || (0x44 != srb->cmnd[3]) || (0x20 != srb->cmnd[4]) ||
+			(0x43 != srb->cmnd[5]) || (0x61 != srb->cmnd[6]) ||
 			(0x72 != srb->cmnd[7]) || (0x64 != srb->cmnd[8])) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -4158,35 +4158,35 @@ static inline int get_rsp_type(struct scsi_cmnd *srb, u8 *rsp_type, int *rsp_len
 
 	switch (srb->cmnd[10]) {
 		case 0x03:
-			*rsp_type = SD_RSP_TYPE_R0; 
+			*rsp_type = SD_RSP_TYPE_R0;
 			*rsp_len = 0;
 			break;
 
 		case 0x04:
-			*rsp_type = SD_RSP_TYPE_R1; 
+			*rsp_type = SD_RSP_TYPE_R1;
 			*rsp_len = 6;
 			break;
 
 		case 0x05:
-			*rsp_type = SD_RSP_TYPE_R1b; 
+			*rsp_type = SD_RSP_TYPE_R1b;
 			*rsp_len = 6;
 			break;
 
 		case 0x06:
-			*rsp_type = SD_RSP_TYPE_R2; 
+			*rsp_type = SD_RSP_TYPE_R2;
 			*rsp_len = 17;
 			break;
 
 		case 0x07:
-			*rsp_type = SD_RSP_TYPE_R3; 
+			*rsp_type = SD_RSP_TYPE_R3;
 			*rsp_len = 6;
 			break;
-			
+
 		default:
 			return STATUS_FAIL;
 	}
 
-	return STATUS_SUCCESS;	
+	return STATUS_SUCCESS;
 }
 
 int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
@@ -4202,7 +4202,7 @@ int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	retval = sd_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -4212,7 +4212,7 @@ int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		sd_card->pre_cmd_err = 0;
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_CHANGE);
 		TRACE_RET(chip, TRANSPORT_FAILED);
-	}	
+	}
 
 	cmd_idx = srb->cmnd[2] & 0x3F;
 	if (srb->cmnd[1] & 0x02) {
@@ -4222,11 +4222,11 @@ int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		acmd = 1;
 	}
 
-	arg = ((u32)srb->cmnd[3] << 24) | ((u32)srb->cmnd[4] << 16) | 
+	arg = ((u32)srb->cmnd[3] << 24) | ((u32)srb->cmnd[4] << 16) |
 		((u32)srb->cmnd[5] << 8) | srb->cmnd[6];
 
 	retval = get_rsp_type(srb, &rsp_type, &rsp_len);
-	if (retval != STATUS_SUCCESS) {	
+	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
@@ -4266,14 +4266,14 @@ int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (acmd) {
-		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr, 
+		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Cmd_Failed);
 		}
 	}
 
-	retval = ext_sd_send_cmd_get_rsp(chip, cmd_idx, arg, rsp_type, 
+	retval = ext_sd_send_cmd_get_rsp(chip, cmd_idx, arg, rsp_type,
 			sd_card->rsp, rsp_len, 0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_GOTO(chip, SD_Execute_Cmd_Failed);
@@ -4285,7 +4285,7 @@ int sd_execute_no_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			TRACE_GOTO(chip, SD_Execute_Cmd_Failed);
 		}
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	retval = sd_update_lock_status(chip);
 	if (retval != STATUS_SUCCESS) {
@@ -4312,7 +4312,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	unsigned int lun = SCSI_LUN(srb);
-	int retval, rsp_len, i; 
+	int retval, rsp_len, i;
 	int cmd13_checkbit = 0, read_err = 0;
 	u8 cmd_idx, rsp_type, bus_width;
 	u8 send_cmd12 = 0, standby = 0, acmd = 0;
@@ -4328,7 +4328,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_CHANGE);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	retval = sd_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -4348,7 +4348,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	data_len = ((u32)srb->cmnd[7] << 16) | ((u32)srb->cmnd[8] << 8) | srb->cmnd[9];
 
 	retval = get_rsp_type(srb, &rsp_type, &rsp_len);
-	if (retval != STATUS_SUCCESS) {	
+	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
@@ -4358,7 +4358,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if ((sd_card->sd_lock_status & SD_LOCK_1BIT_MODE) == 0) {
 		if (CHK_MMC_8BIT(sd_card)) {
@@ -4377,7 +4377,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 #endif
 
 	if (data_len < 512) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, data_len, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, data_len,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
@@ -4392,14 +4392,14 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (acmd) {
-		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr, 
+		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
 		}
 	}
 
-	if (data_len <= 512) {   
+	if (data_len <= 512) {
 		int min_len;
 		u8 *buf;
 #ifndef USING_PPBUF
@@ -4408,23 +4408,23 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 #endif
 		u16 byte_cnt, blk_cnt;
 		u8 cmd[5];
-		
+
 		byte_cnt = ((u16)(srb->cmnd[8] & 0x03) << 8) | srb->cmnd[9];
 		blk_cnt = 1;
-		
+
 		cmd[0] = 0x40 | cmd_idx;
 		cmd[1] = srb->cmnd[3];
 		cmd[2] = srb->cmnd[4];
 		cmd[3] = srb->cmnd[5];
 		cmd[4] = srb->cmnd[6];
-		
+
 		buf = (u8 *)kmalloc(data_len, GFP_KERNEL);
 		if (buf == NULL) {
 			TRACE_RET(chip, TRANSPORT_ERROR);
 		}
-		
+
 #ifdef USING_PPBUF
-		retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt, 
+		retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt,
 				       blk_cnt, bus_width, buf, data_len, 2000);
 		if (retval != STATUS_SUCCESS) {
 			read_err = 1;
@@ -4434,9 +4434,9 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 #else
 		ptr =  buf;
-		
+
 		for (i = 0; i < (data_len / PPBUF_LEN); i++) {
-			retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt, 
+			retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt,
 					blk_cnt, bus_width, ptr, PPBUF_LEN, 1000);
 			if (retval != STATUS_SUCCESS) {
 				read_err = 1;
@@ -4444,13 +4444,13 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 				rtsx_clear_sd_error(chip);
 				TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
 			}
-			
+
 			ptr += PPBUF_LEN;
 		}
-		
+
 		residue = data_len % PPBUF_LEN;
 		if (residue) {
-			retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt, 
+			retval = sd_read_data(chip, SD_TM_NORMAL_READ, cmd, 5, byte_cnt,
 					blk_cnt, bus_width, ptr, residue, 1000);
 			if (retval != STATUS_SUCCESS) {
 				read_err = 1;
@@ -4460,21 +4460,21 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			}
 		}
 #endif
-		
+
 		min_len = min(data_len, scsi_bufflen(srb));
 		rtsx_stor_set_xfer_buf(buf, min_len, srb);
-		
+
 		kfree(buf);
-	} else if (!(data_len & 0x1FF)) {	
+	} else if (!(data_len & 0x1FF)) {
 		rtsx_init_cmd(chip);
 
 		trans_dma_enable(DMA_FROM_DEVICE, chip, data_len, DMA_512);
 
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_H, 0xFF, 0x02);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, 0x00);
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H,
 				0xFF, (srb->cmnd[7] & 0xFE) >> 1);
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L,
 				0xFF, (u8)((data_len & 0x0001FE00) >> 9));
 
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_CMD0, 0xFF, 0x40 | cmd_idx);
@@ -4488,10 +4488,10 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, SD_TM_AUTO_READ_2 | SD_TRANSFER_START);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
-		
+
 		rtsx_send_cmd_no_wait(chip);
 
-		retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb), 
+		retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb),
 			scsi_sg_count(srb), DMA_FROM_DEVICE, 10000);
 		if (retval < 0) {
 			read_err = 1;
@@ -4516,7 +4516,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (send_cmd12) {
-		retval = ext_sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 
+		retval = ext_sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION,
 				0, SD_RSP_TYPE_R1b, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
@@ -4524,7 +4524,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (data_len < 512) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, 0x200, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, 0x200,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
@@ -4534,18 +4534,18 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
 		}
-		retval = rtsx_write_register(chip, SD_BYTE_CNT_L, 0xFF, 0x00);		
+		retval = rtsx_write_register(chip, SD_BYTE_CNT_L, 0xFF, 0x00);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
 		}
 	}
 
-	if ((srb->cmnd[1] & 0x02) || (srb->cmnd[1] & 0x04)) { 	
+	if ((srb->cmnd[1] & 0x02) || (srb->cmnd[1] & 0x04)) {
 		cmd13_checkbit = 1;
 	}
 
 	for (i = 0; i < 3; i++) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 			SD_RSP_TYPE_R1, NULL, 0, cmd13_checkbit);
 		if (retval == STATUS_SUCCESS) {
 			break;
@@ -4554,7 +4554,7 @@ int sd_execute_read_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_GOTO(chip, SD_Execute_Read_Cmd_Failed);
 	}
-	
+
 	scsi_set_resid(srb, 0);
 	return TRANSPORT_GOOD;
 
@@ -4577,7 +4577,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	unsigned int lun = SCSI_LUN(srb);
-	int retval, rsp_len, i; 
+	int retval, rsp_len, i;
 	int cmd13_checkbit = 0, write_err = 0;
 	u8 cmd_idx, rsp_type;
 	u8 send_cmd12 = 0, standby = 0, acmd = 0;
@@ -4598,7 +4598,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_CHANGE);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-	
+
 	retval = sd_switch_clock(chip);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, TRANSPORT_FAILED);
@@ -4616,19 +4616,19 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	data_len = ((u32)srb->cmnd[7] << 16) | ((u32)srb->cmnd[8] << 8) | srb->cmnd[9];
-	arg = ((u32)srb->cmnd[3] << 24) | ((u32)srb->cmnd[4] << 16) | 
+	arg = ((u32)srb->cmnd[3] << 24) | ((u32)srb->cmnd[4] << 16) |
 		((u32)srb->cmnd[5] << 8) | srb->cmnd[6];
-		
-	
+
+
 #ifdef SUPPORT_SD_LOCK
 	if (cmd_idx == LOCK_UNLOCK) {
 		sd_lock_state = sd_card->sd_lock_status;
-		sd_lock_state &= SD_LOCKED;  
+		sd_lock_state &= SD_LOCKED;
 	}
 #endif
 
 	retval = get_rsp_type(srb, &rsp_type, &rsp_len);
-	if (retval != STATUS_SUCCESS) {	
+	if (retval != STATUS_SUCCESS) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
@@ -4661,7 +4661,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 #endif
 
 	if (data_len < 512) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, data_len, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, data_len,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
@@ -4676,20 +4676,20 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (acmd) {
-		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr, 
+		retval = ext_sd_send_cmd_get_rsp(chip, APP_CMD, sd_card->sd_addr,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 		}
 	}
 
-	retval = ext_sd_send_cmd_get_rsp(chip, cmd_idx, arg, rsp_type, 
+	retval = ext_sd_send_cmd_get_rsp(chip, cmd_idx, arg, rsp_type,
 			sd_card->rsp, rsp_len, 0);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 	}
 
-	if (data_len <= 512) {   
+	if (data_len <= 512) {
 		u16 i;
 		u8 *buf;
 
@@ -4699,17 +4699,17 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		}
 
 		rtsx_stor_get_xfer_buf(buf, data_len, srb);
-		
+
 #ifdef SUPPORT_SD_LOCK
 		if (cmd_idx == LOCK_UNLOCK) {
 			lock_cmd_type = buf[0] & 0x0F;
 		}
 #endif
-		
+
 		if (data_len > 256) {
 			rtsx_init_cmd(chip);
 			for (i = 0; i < 256; i++) {
-				rtsx_add_cmd(chip, WRITE_REG_CMD, 
+				rtsx_add_cmd(chip, WRITE_REG_CMD,
 						PPBUF_BASE2 + i, 0xFF, buf[i]);
 			}
 			retval = rtsx_send_cmd(chip, 0, 250);
@@ -4720,7 +4720,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 			rtsx_init_cmd(chip);
 			for (i = 256; i < data_len; i++) {
-				rtsx_add_cmd(chip, WRITE_REG_CMD, 
+				rtsx_add_cmd(chip, WRITE_REG_CMD,
 						PPBUF_BASE2 + i, 0xFF, buf[i]);
 			}
 			retval = rtsx_send_cmd(chip, 0, 250);
@@ -4731,7 +4731,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		} else {
 			rtsx_init_cmd(chip);
 			for (i = 0; i < data_len; i++) {
-				rtsx_add_cmd(chip, WRITE_REG_CMD, 
+				rtsx_add_cmd(chip, WRITE_REG_CMD,
 						PPBUF_BASE2 + i, 0xFF, buf[i]);
 			}
 			retval = rtsx_send_cmd(chip, 0, 250);
@@ -4744,7 +4744,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		kfree(buf);
 
 		rtsx_init_cmd(chip);
-		
+
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_H, 0xFF, srb->cmnd[8] & 0x03);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, srb->cmnd[9]);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H, 0xFF, 0x00);
@@ -4755,36 +4755,36 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
 
 		retval = rtsx_send_cmd(chip, SD_CARD, 250);
-	} else if (!(data_len & 0x1FF)) {	
+	} else if (!(data_len & 0x1FF)) {
 		rtsx_init_cmd(chip);
 
 		trans_dma_enable(DMA_TO_DEVICE, chip, data_len, DMA_512);
 
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_H, 0xFF, 0x02);
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BYTE_CNT_L, 0xFF, 0x00);
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_H,
 				0xFF, (srb->cmnd[7] & 0xFE) >> 1);
-		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L, 
+		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_BLOCK_CNT_L,
 				0xFF, (u8)((data_len & 0x0001FE00) >> 9));
 
 		rtsx_add_cmd(chip, WRITE_REG_CMD, SD_TRANSFER, 0xFF, SD_TM_AUTO_WRITE_3 | SD_TRANSFER_START);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_TRANSFER, SD_TRANSFER_END, SD_TRANSFER_END);
-		
+
 		rtsx_send_cmd_no_wait(chip);
 
-		retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb), 
+		retval = rtsx_transfer_data(chip, SD_CARD, scsi_sglist(srb), scsi_bufflen(srb),
 			scsi_sg_count(srb), DMA_TO_DEVICE, 10000);
 
 	} else {
 		TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 	}
-	
+
 	if (retval < 0) {
 		write_err = 1;
 		rtsx_clear_sd_error(chip);
 		TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if (cmd_idx == LOCK_UNLOCK) {
 		if (lock_cmd_type == SD_ERASE) {
@@ -4795,15 +4795,15 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 
 		rtsx_init_cmd(chip);
 		rtsx_add_cmd(chip, CHECK_REG_CMD, SD_BUS_STAT, SD_DAT0_STATUS, SD_DAT0_STATUS);
-		rtsx_send_cmd(chip, SD_CARD, 250);   
-		
+		rtsx_send_cmd(chip, SD_CARD, 250);
+
 		retval = sd_update_lock_status(chip);
 		if (retval != STATUS_SUCCESS) {
 			RTSX_DEBUGP(("Lock command fail!\n"));
 			lock_cmd_fail = 1;
 		}
 	}
-#endif 
+#endif
 
 	if (standby) {
 		retval = sd_select_card(chip, 1);
@@ -4813,7 +4813,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (send_cmd12) {
-		retval = ext_sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION, 
+		retval = ext_sd_send_cmd_get_rsp(chip, STOP_TRANSMISSION,
 				0, SD_RSP_TYPE_R1b, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
@@ -4821,7 +4821,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 
 	if (data_len < 512) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, 0x200, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SET_BLOCKLEN, 0x200,
 				SD_RSP_TYPE_R1, NULL, 0, 0);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
@@ -4831,18 +4831,18 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 		}
-		rtsx_write_register(chip, SD_BYTE_CNT_L, 0xFF, 0x00);		
+		rtsx_write_register(chip, SD_BYTE_CNT_L, 0xFF, 0x00);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 		}
 	}
 
-	if ((srb->cmnd[1] & 0x02) || (srb->cmnd[1] & 0x04)) { 	
+	if ((srb->cmnd[1] & 0x02) || (srb->cmnd[1] & 0x04)) {
 		cmd13_checkbit = 1;
 	}
 
 	for (i = 0; i < 3; i++) {
-		retval = ext_sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr, 
+		retval = ext_sd_send_cmd_get_rsp(chip, SEND_STATUS, sd_card->sd_addr,
 			SD_RSP_TYPE_R1, NULL, 0, cmd13_checkbit);
 		if (retval == STATUS_SUCCESS) {
 			break;
@@ -4851,7 +4851,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_GOTO(chip, SD_Execute_Write_Cmd_Failed);
 	}
-	
+
 #ifdef SUPPORT_SD_LOCK
 	if (cmd_idx == LOCK_UNLOCK) {
 		if (!lock_cmd_fail) {
@@ -4864,7 +4864,7 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			}
 		}
 
-		RTSX_DEBUGP(("sd_lock_state = 0x%x, sd_card->sd_lock_status = 0x%x\n", 
+		RTSX_DEBUGP(("sd_lock_state = 0x%x, sd_card->sd_lock_status = 0x%x\n",
 			     sd_lock_state, sd_card->sd_lock_status));
 		if (sd_lock_state ^ (sd_card->sd_lock_status & SD_LOCKED)) {
 			sd_card->sd_lock_notify = 1;
@@ -4884,13 +4884,13 @@ int sd_execute_write_data(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 			}
 		}
 	}
-	
+
 	if (lock_cmd_fail) {
 		scsi_set_resid(srb, 0);
 		set_sense_type(chip, lun, SENSE_TYPE_NO_SENSE);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
-#endif  
+#endif
 
 	scsi_set_resid(srb, 0);
 	return TRANSPORT_GOOD;
@@ -4928,7 +4928,7 @@ int sd_get_cmd_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
-	data_len = ((u16)srb->cmnd[7] << 8) | srb->cmnd[8];	
+	data_len = ((u16)srb->cmnd[7] << 8) | srb->cmnd[8];
 
 	if (sd_card->last_rsp_type == SD_RSP_TYPE_R0) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
@@ -4941,7 +4941,7 @@ int sd_get_cmd_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	rtsx_stor_set_xfer_buf(sd_card->rsp, count, srb);
 
 	RTSX_DEBUGP(("Response length: %d\n", data_len));
-	RTSX_DEBUGP(("Response: 0x%x 0x%x 0x%x 0x%x\n", 
+	RTSX_DEBUGP(("Response: 0x%x 0x%x 0x%x 0x%x\n",
 		sd_card->rsp[0], sd_card->rsp[1], sd_card->rsp[2], sd_card->rsp[3]));
 
 	scsi_set_resid(srb, 0);
@@ -4965,20 +4965,20 @@ int sd_hw_rst(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
-	if ((0x53 != srb->cmnd[2]) || (0x44 != srb->cmnd[3]) || (0x20 != srb->cmnd[4]) || 
-			(0x43 != srb->cmnd[5]) || (0x61 != srb->cmnd[6]) || 
+	if ((0x53 != srb->cmnd[2]) || (0x44 != srb->cmnd[3]) || (0x20 != srb->cmnd[4]) ||
+			(0x43 != srb->cmnd[5]) || (0x61 != srb->cmnd[6]) ||
 			(0x72 != srb->cmnd[7]) || (0x64 != srb->cmnd[8])) {
 		set_sense_type(chip, lun, SENSE_TYPE_MEDIA_INVALID_CMD_FIELD);
 		TRACE_RET(chip, TRANSPORT_FAILED);
 	}
 
 	switch (srb->cmnd[1] & 0x0F) {
-		case 0:		
+		case 0:
 #ifdef SUPPORT_SD_LOCK
 			if (0x64 == srb->cmnd[9]) {
 				sd_card->sd_lock_status |= SD_SDR_RST;
 			}
-#endif 
+#endif
 			retval = reset_sd_card(chip);
 			if (retval != STATUS_SUCCESS) {
 #ifdef SUPPORT_SD_LOCK
@@ -4993,7 +4993,7 @@ int sd_hw_rst(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 #endif
 			break;
 
-		case 1:		
+		case 1:
 			retval = soft_reset_sd_card(chip);
 			if (retval != STATUS_SUCCESS) {
 				set_sense_type(chip, lun, SENSE_TYPE_MEDIA_NOT_PRESENT);
@@ -5015,7 +5015,7 @@ int sd_hw_rst(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 void sd_cleanup_work(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
-	
+
 	if (sd_card->seq_mode) {
 		RTSX_DEBUGP(("SD: stop transmission\n"));
 		sd_stop_seq_mode(chip);
@@ -5031,28 +5031,28 @@ int sd_power_off_card3v3(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	RTSX_WRITE_REG(chip, CARD_OE, SD_OUTPUT_EN, 0);
-	
+
 	if (!chip->ft2_fast_mode) {
 		retval = card_power_off(chip, SD_CARD);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
-		
+
 		wait_timeout(50);
 	}
-	
+
 	if (chip->asic_code) {
 		retval = sd_pull_ctl_disable(chip);
 		if (retval != STATUS_SUCCESS) {
 			TRACE_RET(chip, STATUS_FAIL);
 		}
 	} else {
-		RTSX_WRITE_REG(chip, FPGA_PULL_CTL, 
+		RTSX_WRITE_REG(chip, FPGA_PULL_CTL,
 			FPGA_SD_PULL_CTL_BIT | 0x20, FPGA_SD_PULL_CTL_BIT);
 	}
-	
+
 	return STATUS_SUCCESS;
 }
 
@@ -5060,20 +5060,20 @@ int release_sd_card(struct rtsx_chip *chip)
 {
 	struct sd_info *sd_card = &(chip->sd_card);
 	int retval;
-	
+
 	RTSX_DEBUGP(("release_sd_card\n"));
-	
+
 	chip->card_ready &= ~SD_CARD;
 	chip->card_fail &= ~SD_CARD;
 	chip->card_wp &= ~SD_CARD;
 
 	chip->sd20_mode = 0;
-	
+
 #ifdef SUPPORT_SD_LOCK
 	sd_card->sd_lock_status = 0;
 	sd_card->sd_erase_status = 0;
 #endif
-	
+
 	memset(sd_card->raw_csd, 0, 16);
 	memset(sd_card->raw_scr, 0, 8);
 	memset(sd_card->raw_cid, 0, 16);
@@ -5082,7 +5082,7 @@ int release_sd_card(struct rtsx_chip *chip)
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
 	}
-	
+
 	retval = sd_change_bank_voltage(chip, SD_IO_3V3);
 	if (retval != STATUS_SUCCESS) {
 		TRACE_RET(chip, STATUS_FAIL);
@@ -5091,11 +5091,10 @@ int release_sd_card(struct rtsx_chip *chip)
 	if (CHK_SD30_SPEED(sd_card)) {
 		RTSX_WRITE_REG(chip, SD30_DRIVE_SEL, 0x07, chip->sd30_drive_sel_3v3);
 	}
-	
+
 	RTSX_WRITE_REG(chip, OCPPARA2, SD_OCP_THD_MASK, chip->sd_400mA_ocp_thd);
 
-	
+
 	return STATUS_SUCCESS;
 }
-
 

--- a/sd.h
+++ b/sd.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -37,22 +37,22 @@
 #define SD_RSP_TIMEOUT		0x04
 #define SD_IO_ERR		0x02
 
-#define GO_IDLE_STATE		0 
-#define	SEND_OP_COND		1	
-#define	ALL_SEND_CID		2	
+#define GO_IDLE_STATE		0
+#define	SEND_OP_COND		1
+#define	ALL_SEND_CID		2
 #define	SET_RELATIVE_ADDR	3
 #define	SEND_RELATIVE_ADDR	3
 #define	SET_DSR			4
 #define IO_SEND_OP_COND		5
-#define	SWITCH			6	
-#define	SELECT_CARD		7	
+#define	SWITCH			6
+#define	SELECT_CARD		7
 #define	DESELECT_CARD		7
-#define	SEND_EXT_CSD		8	
+#define	SEND_EXT_CSD		8
 #define	SEND_IF_COND		8
-#define	SEND_CSD		9	
+#define	SEND_CSD		9
 #define	SEND_CID		10
 #define	VOLTAGE_SWITCH	    	11
-#define	READ_DAT_UTIL_STOP	11	
+#define	READ_DAT_UTIL_STOP	11
 #define	STOP_TRANSMISSION	12
 #define	SEND_STATUS		13
 #define	GO_INACTIVE_STATE	15
@@ -102,7 +102,7 @@
 
 #define	NO_ARGUMENT	                        0x00
 #define	CHECK_PATTERN	                    	0x000000AA
-#define	VOLTAGE_SUPPLY_RANGE	            	0x00000100	
+#define	VOLTAGE_SUPPLY_RANGE	            	0x00000100
 #define	SUPPORT_HIGH_AND_EXTENDED_CAPACITY	0x40000000
 #define	SUPPORT_MAX_POWER_PERMANCE	        0x10000000
 #define	SUPPORT_1V8	                        0x01000000
@@ -125,17 +125,17 @@
 
 #define SD_PWD_LEN		0x10
 
-#define SD_LOCKED		0x80 
-#define SD_LOCK_1BIT_MODE	0x40 
+#define SD_LOCKED		0x80
+#define SD_LOCK_1BIT_MODE	0x40
 #define SD_PWD_EXIST		0x20
-#define SD_UNLOCK_POW_ON	0x01 
-#define SD_SDR_RST		0x02 
+#define SD_UNLOCK_POW_ON	0x01
+#define SD_SDR_RST		0x02
 
 #define SD_NOT_ERASE		0x00
 #define SD_UNDER_ERASING	0x01
 #define SD_COMPLETE_ERASE	0x02
 
-#define SD_RW_FORBIDDEN		0x0F    
+#define SD_RW_FORBIDDEN		0x0F
 
 #endif
 
@@ -144,7 +144,7 @@
 #define	SDR50_SUPPORT			0x02
 #define	SDR104_SUPPORT	        	0x03
 #define	DDR50_SUPPORT		    	0x04
-                                
+
 #define	HS_SUPPORT_MASK	        	0x02
 #define	SDR50_SUPPORT_MASK	    	0x04
 #define	SDR104_SUPPORT_MASK	    	0x08
@@ -160,7 +160,7 @@
 #define	SDR104_SWITCH_BUSY      	0x08
 #define	DDR50_SWITCH_BUSY       	0x10
 
-#define	FUNCTION_GROUP1_SUPPORT_OFFSET       0x0D   
+#define	FUNCTION_GROUP1_SUPPORT_OFFSET       0x0D
 #define FUNCTION_GROUP1_QUERY_SWITCH_OFFSET  0x10
 #define FUNCTION_GROUP1_CHECK_BUSY_OFFSET    0x1D
 
@@ -168,7 +168,7 @@
 #define	DRIVING_TYPE_B		    0x00
 #define	DRIVING_TYPE_C		    0x02
 #define	DRIVING_TYPE_D	        0x03
-                                
+
 #define	DRIVING_TYPE_A_MASK	    0x02
 #define	DRIVING_TYPE_B_MASK	    0x01
 #define	DRIVING_TYPE_C_MASK	    0x04
@@ -184,7 +184,7 @@
 #define	TYPE_C_SWITCH_BUSY      0x04
 #define	TYPE_D_SWITCH_BUSY      0x08
 
-#define	FUNCTION_GROUP3_SUPPORT_OFFSET       0x09   
+#define	FUNCTION_GROUP3_SUPPORT_OFFSET       0x09
 #define FUNCTION_GROUP3_QUERY_SWITCH_OFFSET  0x0F
 #define FUNCTION_GROUP3_CHECK_BUSY_OFFSET    0x19
 
@@ -202,17 +202,17 @@
 #define	CURRENT_LIMIT_400_QUERY_SWITCH_OK    0x01
 #define	CURRENT_LIMIT_600_QUERY_SWITCH_OK    0x02
 #define	CURRENT_LIMIT_800_QUERY_SWITCH_OK    0x03
-                                             
+
 #define	CURRENT_LIMIT_200_SWITCH_BUSY        0x01
 #define	CURRENT_LIMIT_400_SWITCH_BUSY	     0x02
 #define	CURRENT_LIMIT_600_SWITCH_BUSY        0x04
 #define	CURRENT_LIMIT_800_SWITCH_BUSY        0x08
 
-#define	FUNCTION_GROUP4_SUPPORT_OFFSET       0x07   
+#define	FUNCTION_GROUP4_SUPPORT_OFFSET       0x07
 #define FUNCTION_GROUP4_QUERY_SWITCH_OFFSET  0x0F
 #define FUNCTION_GROUP4_CHECK_BUSY_OFFSET    0x17
 
-#define	DATA_STRUCTURE_VER_OFFSET	0x11	
+#define	DATA_STRUCTURE_VER_OFFSET	0x11
 
 #define MAX_PHASE			31
 
@@ -276,7 +276,7 @@ int sd_power_off_card3v3(struct rtsx_chip *chip);
 int release_sd_card(struct rtsx_chip *chip);
 #ifdef SUPPORT_CPRM
 int soft_reset_sd_card(struct rtsx_chip *chip);
-int ext_sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx, 
+int ext_sd_send_cmd_get_rsp(struct rtsx_chip *chip, u8 cmd_idx,
 		u32 arg, u8 rsp_type, u8 *rsp, int rsp_len, int special_check);
 int ext_sd_get_rsp(struct rtsx_chip *chip, int len, u8 *rsp, u8 rsp_type);
 
@@ -288,5 +288,5 @@ int sd_get_cmd_rsp(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 int sd_hw_rst(struct scsi_cmnd *srb, struct rtsx_chip *chip);
 #endif
 
-#endif  
+#endif
 

--- a/trace.h
+++ b/trace.h
@@ -1,7 +1,7 @@
 /* Driver for Realtek PCI-Express card reader
  * Header file
  *
- * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.  
+ * Copyright(c) 2009 Realtek Semiconductor Corp. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -128,11 +128,11 @@ static inline void rtsx_dump(u8 *buf, int buf_len)
 	int i;
 	u8 tmp[16] = {0};
 	u8 *_ptr = buf;
-	
+
 	for (i = 0; i < ((buf_len)/16); i++) {
 		RTSX_DEBUGP(("%02x %02x %02x %02x %02x %02x %02x %02x "
 			"%02x %02x %02x %02x %02x %02x %02x %02x\n",
-			_ptr[0], _ptr[1], _ptr[2], _ptr[3], _ptr[4], _ptr[5], 
+			_ptr[0], _ptr[1], _ptr[2], _ptr[3], _ptr[4], _ptr[5],
 			_ptr[6], _ptr[7], _ptr[8], _ptr[9], _ptr[10], _ptr[11],
 			_ptr[12], _ptr[13], _ptr[14], _ptr[15]));
 		_ptr += 16;
@@ -145,7 +145,7 @@ static inline void rtsx_dump(u8 *buf, int buf_len)
 			_ptr[0], _ptr[1], _ptr[2], _ptr[3], _ptr[4], _ptr[5],
 			_ptr[6], _ptr[7], _ptr[8], _ptr[9], _ptr[10], _ptr[11],
 			_ptr[12], _ptr[13], _ptr[14], _ptr[15]));
-	}	
+	}
 }
 
 #define RTSX_DUMP(buf, buf_len)		rtsx_dump((u8 *)(buf), (buf_len))
@@ -154,4 +154,4 @@ static inline void rtsx_dump(u8 *buf, int buf_len)
 #define RTSX_DUMP(buf, buf_len)
 #endif
 
-#endif  
+#endif


### PR DESCRIPTION
Resolves #12 

Test on linux 6.0.10

I also removed all ifdef for older kernel versions, which aren't even used by debian stable anymore. People on those old kernel verions will be competent enough to checkout a older tag.